### PR TITLE
ui: Add another unit test.

### DIFF
--- a/src/app/shared/services/api/rgw.service.spec.ts
+++ b/src/app/shared/services/api/rgw.service.spec.ts
@@ -26,10 +26,17 @@ describe('RgwService', () => {
     expect(req.request.method).toBe('GET');
   });
 
-  it('should build valid URL', () => {
+  it('should build valid URL [1]', () => {
     const req = httpTesting.expectOne('/assets/rgw_service.config.json');
     req.flush({ url: 'api/' });
     // @ts-ignore
     expect(service.buildUrl('/foo/bar/')).toBe('api/foo/bar/');
+  });
+
+  it('should build valid URL [2]', () => {
+    const req = httpTesting.expectOne('/assets/rgw_service.config.json');
+    req.flush({ url: 'https://xyz/abc' });
+    // @ts-ignore
+    expect(service.buildUrl('/foo/bar/')).toBe('https://xyz/abc/foo/bar/');
   });
 });


### PR DESCRIPTION
Add another unit test to show how to inject a whole new target URL for the RGW service.

Signed-off-by: Volker Theile <vtheile@suse.com>