### PR TITLE
Create bucket for owner directly instead of linking it.

### DIFF
--- a/src/app/pages/bucket/bucket-form-page/bucket-form-page.component.ts
+++ b/src/app/pages/bucket/bucket-form-page/bucket-form-page.component.ts
@@ -100,6 +100,7 @@ export class BucketFormPageComponent implements OnInit {
           label: TEXT('ID'),
           value: '',
           readonly: true,
+          submitValue: editing,
           groupClass: editing ? '' : 'd-none',
           hasCopyToClipboardButton: true
         },

--- a/src/app/shared/services/api/user.service.ts
+++ b/src/app/shared/services/api/user.service.ts
@@ -139,6 +139,10 @@ export class UserService {
     return this.rgwService.put<void>('admin/user?key', { credentials, params });
   }
 
+  public getKey(uid: string): Observable<Key> {
+    return this.get(uid).pipe(map((user: User) => user.keys[0]));
+  }
+
   /**
    * https://docs.ceph.com/en/latest/radosgw/adminops/#remove-key
    */


### PR DESCRIPTION
Use the credentials of the specified user to create a bucket instead of link that user to a bucket that was created via the admin account.

This approach will workaround the issue https://github.com/aquarist-labs/s3gw/issues/86 to be able to create buckets, but updating a bucket, e.g. linking it to another user, is still broken.

Signed-off-by: Volker Theile <vtheile@suse.com>