### PR TITLE
ci: add build and release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,58 @@
+---
+name: Build S3GW UI
+on:
+
+  push:
+    branches:
+      - 'main'
+
+  workflow_call:
+    inputs:
+      tag:
+        description: "A tag to use for the container image."
+        required: false
+        default: "latest"
+        type: string
+      ref:
+        description: "The git ref to checkout and build."
+        required: false
+        default: "main"
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Dockerhub Login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Container Image Tag
+        id: tag
+        run: |
+          if [ -z "${{ inputs.tag }}" ]; then
+            echo ::set-ouput name=tag::"latest"
+          else
+            echo ::set-ouput name=tag::"${{ inputs.tag }}"
+          fi
+
+      - name: Build and Push Container
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/s3gw-ui:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+---
+name: Unit Tests for S3GW UI
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout S3GW UI
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies and Build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Run Unit Tests
+        run: |
+          npm run test:ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:lts-alpine as builder
+
+COPY . /srv/app
+WORKDIR /srv/app
+RUN npm ci \
+ && npm run build:prod
+
+FROM node:lts-alpine
+
+COPY --from=builder /srv/app/dist/s3gw-ui /app
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+RUN apk --no-cache add gettext \
+ && npm install -g http-server \
+ && chmod +x /usr/bin/entrypoint.sh
+
+WORKDIR /app
+STOPSIGNAL SIGINT
+EXPOSE 8080
+ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+envsubst < /app/assets/rgw_service.config.json.sample \
+  > /app/assets/rgw_service.config.json
+exec http-server /app/


### PR DESCRIPTION
Add github workflow to build and release the container image containing
the s3gw-ui application.
This is mostly a prototype at the moment to get the pipeline working
will receive changes to push to the real destination once it is up and
running.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>