### PR TITLE
Work-around a bug in Firefox where widgets are broken even if `break-inside: avoid` is set.

### DIFF
--- a/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -1,4 +1,4 @@
-<div class="content m-3">
+<div class="widgets m-3">
   <s3gw-dashboard-widget-users></s3gw-dashboard-widget-users>
   <s3gw-dashboard-widget-buckets></s3gw-dashboard-widget-buckets>
 </div>

--- a/src/app/pages/dashboard-page/dashboard-page.component.scss
+++ b/src/app/pages/dashboard-page/dashboard-page.component.scss
@@ -1,22 +1,22 @@
-.content {
+.widgets {
   column-count: 1;
   column-gap: 1rem;
 }
 
 @media only screen and (min-width: 600px) {
-  .content {
+  .widgets {
     column-count: 2;
   }
 }
 
 @media only screen and (min-width: 1280px) {
-  .content {
+  .widgets {
     column-count: 3;
   }
 }
 
 @media only screen and (min-width: 1920px) {
-  .content {
+  .widgets {
     column-count: 4;
   }
 }

--- a/src/app/shared/components/dashboard-widget/dashboard-widget.component.scss
+++ b/src/app/shared/components/dashboard-widget/dashboard-widget.component.scss
@@ -3,6 +3,10 @@
 .card {
   border-width: 0;
   break-inside: avoid;
+  // Work-around a bug in Firefox where widgets are broken even if
+  // `break-inside: avoid` is set.
+  // https://stackoverflow.com/a/67873739
+  overflow: hidden;
 
   .progress {
     height: 0.25rem;


### PR DESCRIPTION
![Bildschirmfoto vom 2022-09-09 12-17-23](https://user-images.githubusercontent.com/1897962/189331691-7091c325-ea98-4996-8fe9-3af6739607b8.png)

Signed-off-by: Volker Theile <vtheile@suse.com>