### PR TITLE
Mock locale settings of Date.

### DIFF
--- a/src/app/shared/pipes/locale-date.pipe.spec.ts
+++ b/src/app/shared/pipes/locale-date.pipe.spec.ts
@@ -5,25 +5,34 @@ import { LocaleDatePipe } from '~/app/shared/pipes/locale-date.pipe';
 describe('LocaleDatePipe', () => {
   const pipe = new LocaleDatePipe();
 
-  beforeEach(() => {
-    dayjs.locale('de');
-  });
-
   it('create an instance', () => {
     expect(pipe).toBeTruthy();
   });
 
   it('transform date into human readable time (1)', () => {
+    jest
+      .spyOn(pipe, 'toLocaleString')
+      .mockImplementation((dt: Date) => dt.toLocaleString('de-DE', { timeZone: 'Europe/Berlin' }));
     const date: Date = dayjs('2022-08-17T10:35:10.543Z').toDate();
     expect(pipe.transform(date, 'datetime')).toBe('17.8.2022, 12:35:10');
   });
 
   it('transform date into human readable time (2)', () => {
+    jest
+      .spyOn(pipe, 'toLocaleString')
+      .mockImplementation((dt: Date) =>
+        dt.toLocaleTimeString('de-DE', { timeZone: 'Europe/Berlin' })
+      );
     const date: Date = dayjs('2022-08-17T10:35:10.543Z').toDate();
     expect(pipe.transform(date, 'time')).toBe('12:35:10');
   });
 
   it('transform date into human readable time (3)', () => {
+    jest
+      .spyOn(pipe, 'toLocaleString')
+      .mockImplementation((dt: Date) =>
+        dt.toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
+      );
     const date: Date = dayjs('2022-08-17T10:35:10.543Z').toDate();
     expect(pipe.transform(date, 'date')).toBe('17.8.2022');
   });

--- a/src/app/shared/pipes/locale-date.pipe.ts
+++ b/src/app/shared/pipes/locale-date.pipe.ts
@@ -13,11 +13,15 @@ export class LocaleDatePipe implements PipeTransform {
    *
    * @param value The date/time value. If it is a number, a UNIX epoch
    *   timestamp is assumed.
-   * @param dateFormat The format to use, e.g. 'date', 'time' or 'datetime'.
+   * @param format The format to use, e.g. 'date', 'time' or 'datetime'.
    *   Defaults to 'date'.
    * @return The time in the given format or an empty string on failure.
    */
-  transform(value: Date | string | number, dateFormat?: string, options?: any): any {
+  transform(
+    value: Date | string | number,
+    format?: 'date' | 'time' | 'datetime',
+    options?: any
+  ): any {
     if (!(_.isString(value) || _.isDate(value) || _.isNumber(value))) {
       return '';
     }
@@ -30,17 +34,21 @@ export class LocaleDatePipe implements PipeTransform {
     if (!date.isValid()) {
       return '';
     }
+    return this.toLocaleString(date.toDate(), format);
+  }
+
+  toLocaleString(date: Date, format?: 'date' | 'time' | 'datetime'): string {
     let result;
-    switch (dateFormat) {
+    switch (format) {
       case 'datetime':
-        result = date.toDate().toLocaleString();
+        result = date.toLocaleString();
         break;
       case 'time':
-        result = date.toDate().toLocaleTimeString();
+        result = date.toLocaleTimeString();
         break;
       case 'date':
       default:
-        result = date.toDate().toLocaleDateString();
+        result = date.toLocaleDateString();
         break;
     }
     return result;


### PR DESCRIPTION
Mocking locale related Date methods are necessary because timezone and locales are not equal on each test system.

Signed-off-by: Volker Theile <vtheile@suse.com>