### PR TITLE
Adapt the key management page to the look of the rest of the UI.

### DIFF
--- a/src/app/pages/user/user-datatable-page/user-datatable-page.component.ts
+++ b/src/app/pages/user/user-datatable-page/user-datatable-page.component.ts
@@ -151,7 +151,7 @@ export class UserDatatablePageComponent {
   onActionMenu(user: User): DatatableActionItem[] {
     // Make sure the logged-in user can't be deleted.
     const credentials = this.authStorageService.getCredentials();
-    const userDeletable = _.some(user.keys, ['access_key', credentials.accessKey]);
+    const deletable = _.some(user.keys, ['access_key', credentials.accessKey]);
     // Build the action menu.
     const result: DatatableActionItem[] = [
       {
@@ -174,7 +174,7 @@ export class UserDatatablePageComponent {
       {
         title: TEXT('Delete'),
         icon: this.icons.delete,
-        disabled: userDeletable,
+        disabled: deletable,
         callback: (data: DatatableData) => {
           this.dialogService.open(
             ModalComponent,

--- a/src/app/pages/user/user-key-datatable-page/user-key-datatable-page.component.html
+++ b/src/app/pages/user/user-key-datatable-page/user-key-datatable-page.component.html
@@ -6,12 +6,10 @@
             ngbTooltip="{{ 'Reload' | transloco }}">
       <i [class]="icons.reload"></i>
     </button>
-    <div class="vr"></div>
     <button type="button"
-            class="btn btn-outline-primary"
+            class="btn btn-primary"
             (click)="onAdd()">
-      <i [class]="icons.plus"></i>
-      {{ "Add Key" | transloco }}
+      {{ "Create" | transloco }}
     </button>
   </div>
   <s3gw-datatable [data]="keys"

--- a/src/app/pages/user/user-key-datatable-page/user-key-datatable-page.component.ts
+++ b/src/app/pages/user/user-key-datatable-page/user-key-datatable-page.component.ts
@@ -17,6 +17,7 @@ import {
 } from '~/app/shared/models/datatable-column.type';
 import { DatatableData } from '~/app/shared/models/datatable-data.type';
 import { Key, User, UserService } from '~/app/shared/services/api/user.service';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { DialogService } from '~/app/shared/services/dialog.service';
 
 @Component({
@@ -37,6 +38,7 @@ export class UserKeyDatatablePageComponent implements OnInit {
   private firstLoadComplete = false;
 
   constructor(
+    private authStorageService: AuthStorageService,
     private dialogService: DialogService,
     private route: ActivatedRoute,
     private router: Router,
@@ -100,6 +102,9 @@ export class UserKeyDatatablePageComponent implements OnInit {
   }
 
   onActionMenu(key: Key): DatatableActionItem[] {
+    // Make sure the currently used key can't be deleted.
+    const credentials = this.authStorageService.getCredentials();
+    const deletable = _.some(this.keys, ['secret_key', credentials.secretKey]);
     const result: DatatableActionItem[] = [
       {
         title: TEXT('Show Key'),
@@ -144,6 +149,7 @@ export class UserKeyDatatablePageComponent implements OnInit {
       {
         title: TEXT('Delete Key'),
         icon: this.icons.delete,
+        disabled: deletable,
         callback: (data: DatatableData) => {
           this.dialogService.open(
             ModalComponent,

--- a/src/app/shared/components/page-status/page-status.component.scss
+++ b/src/app/shared/components/page-status/page-status.component.scss
@@ -2,6 +2,7 @@
   display: grid;
 
   .progress {
+    background-color: transparent;
     border-radius: unset;
     height: 0.25rem;
 


### PR DESCRIPTION
![Bildschirmfoto vom 2022-09-29 12-43-23](https://user-images.githubusercontent.com/1897962/193011299-4baad4f3-f07a-4fb8-9ae4-f6267c8148f0.png)

- Make sure the currently used key can't be deleted.
- Make the background of the page status progress bar transparent.

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
