### PR TITLE
Make the test workflow mandatory for PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,28 @@
 ---
-name: Unit Tests for S3GW UI
+name: Lint & Unit Tests for S3GW UI
 on:
   push:
     branches:
       - '*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout S3GW UI
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Lint
+        run: npm run lint
+
   test:
     runs-on: ubuntu-latest
 
@@ -14,11 +31,8 @@ jobs:
       - name: Checkout S3GW UI
         uses: actions/checkout@v3
 
-      - name: Install Dependencies and Build
-        run: |
-          npm ci
-          npm run build
+      - name: Install Dependencies
+        run: npm ci
 
       - name: Run Unit Tests
-        run: |
-          npm run test:ci
+        run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test:ci": "jest --no-cache",
     "lint:eslint": "ng lint",
     "lint:html": "htmllint src/app/**/*.html && html-linter --config html-linter.config.json",
-    "lint:prettier": "prettier --list-different \"src/**/*.{ts,scss}\"",
     "lint:scss": "stylelint \"**/*.scss\"",
     "lint": "run-p -csl --aggregate-output lint:*",
     "fix:prettier": "prettier --write \"{src,e2e}/**/*.{ts,scss}\"",


### PR DESCRIPTION
- Make the test workflow mandatory for PRs.
- Add lint job.
- No need to build the app for testing.
- Remove the 'lint:prettier' step in packages.json because this is done by eslint.

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
