### PR TITLE
UI: `sortHeader` field not set correct.

### DIFF
--- a/src/app/shared/components/datatable/datatable.component.ts
+++ b/src/app/shared/components/datatable/datatable.component.ts
@@ -186,7 +186,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
       }, 0);
     }
     this.sortableColumns = this.columns
-      .filter((c) => c.sortable === true)
+      .filter((c) => c.sortable === true && this.getSortProp(c))
       .map((c) => this.getSortProp(c));
     if (!this.sortHeader && this.sortableColumns.length > 0) {
       this.sortHeader = this.sortableColumns[0];


### PR DESCRIPTION
If the `sortHeader` parameter is not set, the first entry of the list of sortable headers is chosen. If the `prop` field is not set, this will cause problems. To prevent this, the filter needs to be enhanced.

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
