### PR TITLE
Remove base-href from index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>s3gw</title>
-  <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" href="favicon_180x180.png">


### PR DESCRIPTION
... which is not necessary when using [HashLocationStrategy](https://github.com/aquarist-labs/s3gw-ui/blob/main/src/app/app-routing.module.ts#L44). This strategy doesn’t require any co-operation from the server side. It also does not care about if path prefixes are used which simplifies various setups.

Fixes: https://github.com/aquarist-labs/s3gw/issues/239

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
