### PR TITLE
UI: Editing buckets in `user` mode is not possible because form is in `Create` mode only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Editing buckets in user mode is not possible (gh#aquarist-labs/s3gw#262).
+- Editing buckets in `user` mode is not possible (gh#aquarist-labs/s3gw#262).
 - A page reload does not re-enable the 'administration' switch (gh#aquarist-labs/s3gw#284).
+- Editing buckets in `user` mode is not possible because form is in
+  `Create` mode only (gh#aquarist-labs/s3gw#290).
 
+UI: 
 ### Added
 
 - Add search field to data tables (gh#aquarist-labs/s3gw#157).

--- a/src/app/pages/user/bucket/bucket-form-page/bucket-form-page.component.ts
+++ b/src/app/pages/user/bucket/bucket-form-page/bucket-form-page.component.ts
@@ -35,7 +35,7 @@ export class BucketFormPageComponent implements OnInit, IsDirty {
     private s3BucketService: S3BucketService,
     private router: Router
   ) {
-    this.createForm(this.router.url.startsWith(`/user/buckets/edit`));
+    this.createForm(this.router.url.startsWith(`/buckets/edit`));
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
The form will be displayed in `Create` mode instead of `Edit`. This will lead in a `Bucket already exists` when pressing the form submit button.

Fixes: https://github.com/aquarist-labs/s3gw/issues/290

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
