### PR TITLE
UI: Improve navigation.

### DIFF
--- a/src/app/pages/admin/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
+++ b/src/app/pages/admin/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
@@ -55,7 +55,7 @@ export class BucketDatatablePageComponent {
         enabledConstraints: {
           minSelected: 1
         },
-        callback: (table: Datatable) => this.doDelete(table.selected)
+        callback: (event: Event, table: Datatable) => this.doDelete(table.selected)
       }
     ];
     this.datatableColumns = [

--- a/src/app/pages/admin/user/user-datatable-page/user-datatable-page.component.ts
+++ b/src/app/pages/admin/user/user-datatable-page/user-datatable-page.component.ts
@@ -64,7 +64,7 @@ export class UserDatatablePageComponent {
             }
           ]
         },
-        callback: (table: Datatable) => this.doDelete(table.selected)
+        callback: (event: Event, table: Datatable) => this.doDelete(table.selected)
       }
     ];
     this.datatableColumns = [

--- a/src/app/pages/user/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
+++ b/src/app/pages/user/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
@@ -56,7 +56,7 @@ export class BucketDatatablePageComponent {
         enabledConstraints: {
           minSelected: 1
         },
-        callback: (table: Datatable) => this.doDelete(table.selected)
+        callback: (event: Event, table: Datatable) => this.doDelete(table.selected)
       }
     ];
     this.datatableColumns = [

--- a/src/app/pages/user/bucket/bucket-form-page/bucket-form-page.component.html
+++ b/src/app/pages/user/bucket/bucket-form-page/bucket-form-page.component.html
@@ -1,4 +1,5 @@
-<s3gw-wrapper-status [pageStatus]="pageStatus"
+<s3gw-wrapper-status [actions]="pageActions"
+                     [pageStatus]="pageStatus"
                      [loadingErrorText]="loadingErrorText"
                      [savingErrorText]="savingErrorText">
   <s3gw-declarative-form [config]="config"></s3gw-declarative-form>

--- a/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
+++ b/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Params } from '@angular/router';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as AWS from 'aws-sdk';
 import * as _ from 'lodash';
@@ -64,10 +64,17 @@ export class ObjectDatatablePageComponent implements OnInit {
     private modalDialogService: ModalDialogService,
     private notificationService: NotificationService,
     private route: ActivatedRoute,
+    private router: Router,
     private rxjsUiHelperService: RxjsUiHelperService,
     private s3bucketService: S3BucketService
   ) {
     this.datatableActions = [
+      {
+        type: 'file',
+        text: TEXT('Upload'),
+        icon: this.icons.upload,
+        callback: (event: Event) => this.doUpload((event.target as HTMLInputElement).files)
+      },
       {
         type: 'button',
         text: TEXT('Download'),
@@ -75,7 +82,7 @@ export class ObjectDatatablePageComponent implements OnInit {
         enabledConstraints: {
           minSelected: 1
         },
-        callback: (table: Datatable) => this.doDownload(table.selected)
+        callback: (event: Event, table: Datatable) => this.doDownload(table.selected)
       },
       {
         type: 'button',
@@ -84,7 +91,7 @@ export class ObjectDatatablePageComponent implements OnInit {
         enabledConstraints: {
           minSelected: 1
         },
-        callback: (table: Datatable) => this.doDelete(table.selected)
+        callback: (event: Event, table: Datatable) => this.doDelete(table.selected)
       }
     ];
     this.datatableColumns = [
@@ -111,10 +118,10 @@ export class ObjectDatatablePageComponent implements OnInit {
     ];
     this.pageActions = [
       {
-        type: 'file',
-        text: TEXT('Upload'),
-        icon: this.icons.upload,
-        callback: (event: Event) => this.doUpload((event.target as HTMLInputElement).files)
+        type: 'button',
+        text: TEXT('Edit'),
+        icon: Icon.edit,
+        callback: () => this.router.navigate([`/buckets/edit/${this.bid}`])
       }
     ];
   }

--- a/src/app/shared/components/datatable-actions/datatable-actions.component.html
+++ b/src/app/shared/components/datatable-actions/datatable-actions.component.html
@@ -1,20 +1,38 @@
-<ng-container *ngFor="let action of actions">
-  <ng-container [ngSwitch]="action.type">
-    <ng-template [ngSwitchCase]="'button'">
-      <button type="button"
-              class="btn btn-primary me-2"
-              ngbTooltip="{{ action.tooltip | transloco }}"
-              [disabled]="isDisabled(action)"
-              (click)="onAction(action)">
-        <i *ngIf="action.icon"
-           [class]="action.icon">
-        </i>
-        {{ action.text | transloco }}
-      </button>
-    </ng-template>
+<div class="actions">
+  <ng-container *ngFor="let action of actions">
+    <ng-container [ngSwitch]="action.type">
+      <ng-template [ngSwitchCase]="'button'">
+        <button type="button"
+                class="btn btn-primary"
+                ngbTooltip="{{ action.tooltip | transloco }}"
+                [disabled]="isDisabled(action)"
+                (click)="onAction($event, action)">
+          <i *ngIf="action.icon"
+             [class]="action.icon">
+          </i>
+          {{ action.text | transloco }}
+        </button>
+      </ng-template>
 
-    <ng-template [ngSwitchCase]="'divider'">
-      <div class="vr me-2"></div>
-    </ng-template>
+      <ng-template [ngSwitchCase]="'file'">
+        <input type="file"
+               id="file"
+               hidden
+               multiple
+               (change)="onAction($event, action)">
+        <label for="file"
+               class="btn btn-primary"
+               ngbTooltip="{{ action.tooltip | transloco }}">
+          <i *ngIf="action.icon"
+             [class]="action.icon">
+          </i>
+          {{ action.text | transloco }}
+        </label>
+      </ng-template>
+
+      <ng-template [ngSwitchCase]="'divider'">
+        <div class="vr"></div>
+      </ng-template>
+    </ng-container>
   </ng-container>
-</ng-container>
+</div>

--- a/src/app/shared/components/datatable-actions/datatable-actions.component.scss
+++ b/src/app/shared/components/datatable-actions/datatable-actions.component.scss
@@ -1,0 +1,5 @@
+.actions {
+  display: grid;
+  gap: 0.5rem;
+  grid-auto-flow: column;
+}

--- a/src/app/shared/components/datatable-actions/datatable-actions.component.ts
+++ b/src/app/shared/components/datatable-actions/datatable-actions.component.ts
@@ -55,9 +55,9 @@ export class DatatableActionsComponent {
     return false;
   }
 
-  onAction(action: DatatableAction): void {
+  onAction(event: Event, action: DatatableAction): void {
     if (this.table && _.isFunction(action.callback)) {
-      action.callback(this.table);
+      action.callback(event, this.table);
     }
   }
 }

--- a/src/app/shared/components/datatable/datatable.component.html
+++ b/src/app/shared/components/datatable/datatable.component.html
@@ -26,13 +26,13 @@
     </div>
   </div>
   <button type="button"
-          class="reload btn btn-simple ms-2"
+          class="reload btn btn-simple"
           (click)="reloadData()"
           ngbTooltip="{{ 'Reload' | transloco }}">
     <i [class]="icons.reload"></i>
   </button>
   <div *ngIf="hasSearchField"
-       class="search input-group ms-2">
+       class="search input-group">
     <!--
     <div class="input-group-text">
       <i class="mdi-18px"

--- a/src/app/shared/components/datatable/datatable.component.scss
+++ b/src/app/shared/components/datatable/datatable.component.scss
@@ -29,9 +29,14 @@ tbody > tr {
 }
 
 .actions {
+  display: grid;
+  gap: 0.5rem;
+  grid-auto-flow: column;
+
   .search {
     &.input-group {
       width: inherit;
+      flex-wrap: nowrap;
     }
 
     .btn.btn-input-group {

--- a/src/app/shared/components/page-actions/page-actions.component.ts
+++ b/src/app/shared/components/page-actions/page-actions.component.ts
@@ -14,7 +14,7 @@ export class PageActionsComponent {
 
   constructor() {}
 
-  onAction(event: any, action: PageAction): void {
+  onAction(event: Event, action: PageAction): void {
     if (_.isFunction(action.callback)) {
       action.callback(event);
     }

--- a/src/app/shared/enum/icon.enum.ts
+++ b/src/app/shared/enum/icon.enum.ts
@@ -22,6 +22,7 @@ export enum Icon {
   apps = 'mdi mdi-apps',
   dotsVertical = 'mdi mdi-dots-vertical',
   show = 'mdi mdi-eye',
+  folderOpen = 'mdi mdi-folder-open',
   download = 'mdi mdi-download',
   chevronUp = 'mdi mdi-chevron-up',
   chevronDown = 'mdi mdi-chevron-down',

--- a/src/app/shared/models/datatable-action.type.ts
+++ b/src/app/shared/models/datatable-action.type.ts
@@ -2,11 +2,11 @@ import { Constraint } from '~/app/shared/models/constraint.type';
 import { Datatable } from '~/app/shared/models/datatable.interface';
 
 export type DatatableAction = {
-  type?: 'button' | 'divider';
+  type?: 'button' | 'file' | 'divider';
   text?: string;
   icon?: string;
   tooltip?: string;
-  callback?: (table: Datatable) => void;
+  callback?: (event: Event, table: Datatable) => void;
   // The constraints that must be fulfilled to enable this action.
   enabledConstraints?: {
     minSelected?: number;


### PR DESCRIPTION
Improve the navigation between bucket and object browser. With the new added buttons in the upper right corners it is easy to switch between the bucket page and the object browser of this bucket. The buttons have been arranged according to the Rancher UI.

![Peek 2023-01-10 16-28](https://user-images.githubusercontent.com/1897962/211592976-5febc377-e4c9-4819-8af4-5a0978cb50e1.gif)

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
