### PR TITLE
Make user stats dashboard widget ready to use.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/router": "~13.3.12",
         "@fontsource/lato": "^4.5.10",
         "@fontsource/roboto-mono": "^4.5.10",
-        "@mdi/font": "6.9.96",
+        "@mdi/font": "^7.1.96",
         "@ng-bootstrap/ng-bootstrap": "^12.1.2",
         "@ngneat/transloco": "^4.2.2",
         "aws-sdk": "^2.1300.0",
@@ -3811,9 +3811,9 @@
       }
     },
     "node_modules/@mdi/font": {
-      "version": "6.9.96",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-6.9.96.tgz",
-      "integrity": "sha512-z3QVZStyHVwkDsFR7A7F2PIvZJPWgdSFw4BEEy2Gc9HUN5NfK9mGbjgaYClRcbMWiYEV45srmiYtczmBtCqR8w=="
+      "version": "7.1.96",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.1.96.tgz",
+      "integrity": "sha512-Imag6npmfkBDi2Ze2jiZVAPTDIKLxhz2Sx82xJ2zctyAU5LYJejLI5ChnDwiD9bMkQfVuzEsI98Q8toHyC+HCg=="
     },
     "node_modules/@ng-bootstrap/ng-bootstrap": {
       "version": "12.1.2",
@@ -25779,9 +25779,9 @@
       }
     },
     "@mdi/font": {
-      "version": "6.9.96",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-6.9.96.tgz",
-      "integrity": "sha512-z3QVZStyHVwkDsFR7A7F2PIvZJPWgdSFw4BEEy2Gc9HUN5NfK9mGbjgaYClRcbMWiYEV45srmiYtczmBtCqR8w=="
+      "version": "7.1.96",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.1.96.tgz",
+      "integrity": "sha512-Imag6npmfkBDi2Ze2jiZVAPTDIKLxhz2Sx82xJ2zctyAU5LYJejLI5ChnDwiD9bMkQfVuzEsI98Q8toHyC+HCg=="
     },
     "@ng-bootstrap/ng-bootstrap": {
       "version": "12.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/router": "~13.3.12",
     "@fontsource/lato": "^4.5.10",
     "@fontsource/roboto-mono": "^4.5.10",
-    "@mdi/font": "6.9.96",
+    "@mdi/font": "^7.1.96",
     "@ng-bootstrap/ng-bootstrap": "^12.1.2",
     "@ngneat/transloco": "^4.2.2",
     "aws-sdk": "^2.1300.0",

--- a/src/app/dashboard/widgets/user-stats-total-bytes/user-stats-total-bytes.component.html
+++ b/src/app/dashboard/widgets/user-stats-total-bytes/user-stats-total-bytes.component.html
@@ -5,8 +5,8 @@
        [class]="icons.sum">
     </i>
     <div class="d-grid gap-0">
-      <div>{{ "Total Bytes" | transloco }}</div>
-      <div class="fs-3 fw-bold">{{ data?.TotalBytes | bytesToSize }}</div>
+      <div>{{ "Used Capacity" | transloco }}</div>
+      <div class="fs-3 fw-bold">{{ data?.Summary?.[5] | bytesToSize | notAvailable }}</div>
     </div>
   </div>
 </s3gw-dashboard-widget>

--- a/src/app/dashboard/widgets/user-stats-total-bytes/user-stats-total-bytes.component.html
+++ b/src/app/dashboard/widgets/user-stats-total-bytes/user-stats-total-bytes.component.html
@@ -1,9 +1,12 @@
 <s3gw-dashboard-widget [loadData]="loadData.bind(this)"
                        (updateData)="updateData($event)">
   <div class="d-flex gap-4 justify-content-start align-items-center">
+    <i class="mdi-36px"
+       [class]="icons.sum">
+    </i>
     <div class="d-grid gap-0">
       <div>{{ "Total Bytes" | transloco }}</div>
-      <div class="fs-3 fw-bold">{{ data?.TotalBytes }}</div>
+      <div class="fs-3 fw-bold">{{ data?.TotalBytes | bytesToSize }}</div>
     </div>
   </div>
 </s3gw-dashboard-widget>

--- a/src/app/dashboard/widgets/user-stats-total-bytes/user-stats-total-bytes.component.spec.ts
+++ b/src/app/dashboard/widgets/user-stats-total-bytes/user-stats-total-bytes.component.spec.ts
@@ -23,10 +23,9 @@ describe('UserStatsTotalBytesComponent', () => {
     component.loadData = () =>
       of({
         /* eslint-disable @typescript-eslint/naming-convention */
-        Summary: {},
-        TotalBytes: 4096,
-        TotalBytesRounded: 1,
-        TotalEntries: 5
+        Entries: [],
+        Summary: [-1, 1000, -1, -1, -1, 122028, 147456, 10],
+        CapacityUsed: []
         /* eslint-enable @typescript-eslint/naming-convention */
       });
     fixture.detectChanges();

--- a/src/app/functions.helper.ts
+++ b/src/app/functions.helper.ts
@@ -28,8 +28,8 @@ export const toBytes = (value: number | string): number | null => {
  * @param value The value to convert.
  * @returns Returns The converted value, e.g. '4 MiB'.
  */
-export const bytesToSize = (value: null | number | string): string => {
-  if (_.isNull(value) || [0, '0', ''].includes(value)) {
+export const bytesToSize = (value: undefined | null | number | string): string => {
+  if (_.isUndefined(value) || _.isNull(value) || [0, '0', ''].includes(value)) {
     return '0 B';
   }
   const bytes = _.toNumber(value);

--- a/src/app/pages/user/dashboard-page/dashboard-page.component.html
+++ b/src/app/pages/user/dashboard-page/dashboard-page.component.html
@@ -1,5 +1,6 @@
 <s3gw-wrapper-status>
   <div class="widgets mt-3">
     <s3gw-dashboard-widget-user-buckets></s3gw-dashboard-widget-user-buckets>
+    <s3gw-user-stats-total-bytes></s3gw-user-stats-total-bytes>
   </div>
 </s3gw-wrapper-status>

--- a/src/app/pages/user/dashboard-page/dashboard-page.component.html
+++ b/src/app/pages/user/dashboard-page/dashboard-page.component.html
@@ -1,6 +1,5 @@
 <s3gw-wrapper-status>
   <div class="widgets mt-3">
     <s3gw-dashboard-widget-user-buckets></s3gw-dashboard-widget-user-buckets>
-    <s3gw-user-stats-total-bytes></s3gw-user-stats-total-bytes>
   </div>
 </s3gw-wrapper-status>

--- a/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
+++ b/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
@@ -7,7 +7,7 @@ import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { merge, Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
-import { format } from '~/app/functions.helper';
+import { bytesToSize, format } from '~/app/functions.helper';
 import { translate } from '~/app/i18n.helper';
 import { DeclarativeFormModalComponent } from '~/app/shared/components/declarative-form-modal/declarative-form-modal.component';
 import { PageStatus } from '~/app/shared/components/page-wrapper/page-wrapper.component';
@@ -22,7 +22,6 @@ import { DatatableData } from '~/app/shared/models/datatable-data.type';
 import { DatatableRowAction } from '~/app/shared/models/datatable-row-action.type';
 import { DeclarativeFormModalConfig } from '~/app/shared/models/declarative-form-modal-config.type';
 import { PageAction } from '~/app/shared/models/page-action.type';
-import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
 import { LocaleDatePipe } from '~/app/shared/pipes/locale-date.pipe';
 import {
   S3BucketService,
@@ -58,7 +57,6 @@ export class ObjectDatatablePageComponent implements OnInit {
   private firstLoadComplete = false;
 
   constructor(
-    private bytesToSizePipe: BytesToSizePipe,
     private dialogService: DialogService,
     private localeDatePipe: LocaleDatePipe,
     private modalDialogService: ModalDialogService,
@@ -102,7 +100,7 @@ export class ObjectDatatablePageComponent implements OnInit {
       {
         name: TEXT('Size'),
         prop: 'Size',
-        pipe: this.bytesToSizePipe
+        cellTemplateName: DatatableCellTemplateName.binaryUnit
       },
       {
         name: TEXT('Last Modified'),
@@ -211,7 +209,7 @@ export class ObjectDatatablePageComponent implements OnInit {
                 type: 'text',
                 name: 'size',
                 label: TEXT('Size'),
-                value: this.bytesToSizePipe.transform(data['Size']),
+                value: bytesToSize(data['Size']),
                 readonly: true
               },
               {

--- a/src/app/shared/components/datatable/datatable.component.html
+++ b/src/app/shared/components/datatable/datatable.component.html
@@ -258,3 +258,8 @@
     {{ column.cellTemplateConfig?.text }}
   </button>
 </ng-template>
+
+<ng-template #binaryUnitTpl
+             let-value="value">
+  <span>{{ value | bytesToSize | notAvailable }}</span>
+</ng-template>

--- a/src/app/shared/components/datatable/datatable.component.ts
+++ b/src/app/shared/components/datatable/datatable.component.ts
@@ -52,6 +52,8 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy {
   localeDateTimeTpl?: TemplateRef<any>;
   @ViewChild('buttonTpl', { static: true })
   buttonTpl?: TemplateRef<any>;
+  @ViewChild('binaryUnitTpl', { static: true })
+  binaryUnitTpl?: TemplateRef<any>;
 
   @Input()
   columns: DatatableColumn[] = [];
@@ -215,7 +217,8 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy {
       map: this.mapTpl!,
       badge: this.badgeTpl!,
       localeDateTime: this.localeDateTimeTpl!,
-      button: this.buttonTpl!
+      button: this.buttonTpl!,
+      binaryUnit: this.binaryUnitTpl!
     };
   }
 

--- a/src/app/shared/enum/icon.enum.ts
+++ b/src/app/shared/enum/icon.enum.ts
@@ -34,5 +34,6 @@ export enum Icon {
   search = 'mdi mdi-magnify',
   table = 'mdi mdi-table',
   tags = 'mdi mdi-tag-multiple',
-  bell = 'mdi mdi-bell'
+  bell = 'mdi mdi-bell',
+  sum = 'mdi mdi-sigma'
 }

--- a/src/app/shared/models/datatable-column.type.ts
+++ b/src/app/shared/models/datatable-column.type.ts
@@ -50,7 +50,9 @@ export enum DatatableCellTemplateName {
   //     url: string;
   //   }
   // }
-  button = 'button'
+  button = 'button',
+  // Convert a number of bytes into the highest possible binary unit.
+  binaryUnit = 'binaryUnit'
 }
 
 export type DatatableColumn = {

--- a/src/app/shared/pipes/bytes-to-size.pipe.spec.ts
+++ b/src/app/shared/pipes/bytes-to-size.pipe.spec.ts
@@ -7,6 +7,18 @@ describe('BytesToSizePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
+  it('should not transforms null', () => {
+    expect(pipe.transform(null)).toBeNull();
+  });
+
+  it('should not transforms undefined', () => {
+    expect(pipe.transform(undefined)).toBeUndefined();
+  });
+
+  it('should not transforms empty string', () => {
+    expect(pipe.transform('')).toBe('');
+  });
+
   it('transforms 0 bytes', () => {
     expect(pipe.transform(0)).toBe('0 B');
   });

--- a/src/app/shared/pipes/bytes-to-size.pipe.ts
+++ b/src/app/shared/pipes/bytes-to-size.pipe.ts
@@ -6,7 +6,7 @@ import { bytesToSize } from '~/app/functions.helper';
   name: 'bytesToSize'
 })
 export class BytesToSizePipe implements PipeTransform {
-  transform(value: null | number | string): string {
+  transform(value: undefined | null | number | string): string {
     return bytesToSize(value);
   }
 }

--- a/src/app/shared/pipes/bytes-to-size.pipe.ts
+++ b/src/app/shared/pipes/bytes-to-size.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import * as _ from 'lodash';
 
 import { bytesToSize } from '~/app/functions.helper';
 
@@ -6,7 +7,10 @@ import { bytesToSize } from '~/app/functions.helper';
   name: 'bytesToSize'
 })
 export class BytesToSizePipe implements PipeTransform {
-  transform(value: undefined | null | number | string): string {
+  transform(value: undefined | null | number | string): undefined | null | string {
+    if (_.isUndefined(value) || _.isNull(value) || '' === value) {
+      return value;
+    }
     return bytesToSize(value);
   }
 }

--- a/src/app/shared/pipes/not-available.pipe.spec.ts
+++ b/src/app/shared/pipes/not-available.pipe.spec.ts
@@ -1,0 +1,29 @@
+import { NotAvailablePipe } from '~/app/shared/pipes/not-available.pipe';
+
+describe('NotAvailablePipe', () => {
+  const pipe = new NotAvailablePipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('transforms with value (1)', () => {
+    expect(pipe.transform(undefined)).toBe('n/a');
+  });
+
+  it('transforms with value (2)', () => {
+    expect(pipe.transform(null)).toBe('n/a');
+  });
+
+  it('transforms with value (3)', () => {
+    expect(pipe.transform('')).toBe('n/a');
+  });
+
+  it('transforms with value (4)', () => {
+    expect(pipe.transform(undefined, 'foo')).toBe('foo');
+  });
+
+  it('transforms with some value', () => {
+    expect(pipe.transform('bar')).toBe('bar');
+  });
+});

--- a/src/app/shared/pipes/not-available.pipe.ts
+++ b/src/app/shared/pipes/not-available.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
+import * as _ from 'lodash';
+
+import { translate } from '~/app/i18n.helper';
+
+@Pipe({
+  name: 'notAvailable'
+})
+export class NotAvailablePipe implements PipeTransform {
+  transform(value: unknown, defaultValue?: string): any {
+    return _.isUndefined(value) || _.isNull(value) || _.isNaN(value) || '' === value
+      ? _.defaultTo(defaultValue, translate(TEXT('n/a')))
+      : value;
+  }
+}

--- a/src/app/shared/pipes/pipes.module.ts
+++ b/src/app/shared/pipes/pipes.module.ts
@@ -6,6 +6,7 @@ import { BytesToSizePipe } from '~/app/shared/pipes/bytes-to-size.pipe';
 import { FormatPipe } from '~/app/shared/pipes/format.pipe';
 import { LocaleDatePipe } from '~/app/shared/pipes/locale-date.pipe';
 import { MapPipe } from '~/app/shared/pipes/map.pipe';
+import { NotAvailablePipe } from '~/app/shared/pipes/not-available.pipe';
 import { SanitizePipe } from '~/app/shared/pipes/sanitize.pipe';
 import { ToStringPipe } from '~/app/shared/pipes/to-string.pipe';
 
@@ -17,7 +18,8 @@ import { ToStringPipe } from '~/app/shared/pipes/to-string.pipe';
     LocaleDatePipe,
     MapPipe,
     SanitizePipe,
-    ToStringPipe
+    ToStringPipe,
+    NotAvailablePipe
   ],
   providers: [
     ArrayPipe,
@@ -26,7 +28,8 @@ import { ToStringPipe } from '~/app/shared/pipes/to-string.pipe';
     LocaleDatePipe,
     MapPipe,
     SanitizePipe,
-    ToStringPipe
+    ToStringPipe,
+    NotAvailablePipe
   ],
   exports: [
     ArrayPipe,
@@ -35,7 +38,8 @@ import { ToStringPipe } from '~/app/shared/pipes/to-string.pipe';
     LocaleDatePipe,
     MapPipe,
     SanitizePipe,
-    ToStringPipe
+    ToStringPipe,
+    NotAvailablePipe
   ],
   imports: [CommonModule]
 })

--- a/src/app/shared/services/api/s3-user.service.ts
+++ b/src/app/shared/services/api/s3-user.service.ts
@@ -11,10 +11,9 @@ import { AuthSessionService } from '~/app/shared/services/auth-session.service';
 
 export type S3UserStats = {
   /* eslint-disable @typescript-eslint/naming-convention */
-  Summary: object;
-  TotalBytes: number;
-  TotalBytesRounded: number;
-  TotalEntries: number;
+  Entries: any[];
+  Summary: number[];
+  CapacityUsed: any[];
   /* eslint-enable @typescript-eslint/naming-convention */
 };
 


### PR DESCRIPTION
This PR fully implements the dashboard widget, but it is not displayed in the dashboard right now. Additionally some code cleanup has been done.

Connected to a Ceph RGW the widget already works and the dashboard might look like this:

![Bildschirmfoto vom 2023-01-25 12-26-58](https://user-images.githubusercontent.com/1897962/214551916-2ac20067-d6fc-4791-b78c-5b5e05854a62.png)

![Bildschirmfoto vom 2023-01-25 12-27-10](https://user-images.githubusercontent.com/1897962/214551889-ff3a17a4-c416-4bbd-9735-e6f0c73f1c14.png)

The user stats are currently not available in s3gw, see:
- https://github.com/aquarist-labs/s3gw/issues/82
- https://github.com/aquarist-labs/s3gw/issues/196
- https://github.com/aquarist-labs/s3gw/issues/143

Signed-off-by: Volker Theile <vtheile@suse.com># Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
