### PR TITLE
Break too long table columns.

### DIFF
--- a/src/app/pages/admin/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
+++ b/src/app/pages/admin/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
@@ -62,7 +62,8 @@ export class BucketDatatablePageComponent {
     this.datatableColumns = [
       {
         name: TEXT('Name'),
-        prop: 'bucket'
+        prop: 'bucket',
+        css: 'text-break'
       },
       {
         name: TEXT('Owner'),

--- a/src/app/pages/admin/user/user-datatable-page/user-datatable-page.component.ts
+++ b/src/app/pages/admin/user/user-datatable-page/user-datatable-page.component.ts
@@ -70,7 +70,8 @@ export class UserDatatablePageComponent {
     this.datatableColumns = [
       {
         name: TEXT('User ID'),
-        prop: 'user_id'
+        prop: 'user_id',
+        css: 'text-break'
       },
       {
         name: TEXT('Full Name'),

--- a/src/app/pages/user/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
+++ b/src/app/pages/user/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
@@ -63,7 +63,8 @@ export class BucketDatatablePageComponent {
     this.datatableColumns = [
       {
         name: TEXT('Name'),
-        prop: 'Name'
+        prop: 'Name',
+        css: 'text-break'
       },
       {
         name: TEXT('Created'),

--- a/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
+++ b/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
@@ -97,7 +97,8 @@ export class ObjectDatatablePageComponent implements OnInit {
     this.datatableColumns = [
       {
         name: TEXT('Name'),
-        prop: 'Key'
+        prop: 'Key',
+        css: 'text-break'
       },
       {
         name: TEXT('Size'),


### PR DESCRIPTION
Before:
![Bildschirmfoto vom 2023-01-25 12-46-35](https://user-images.githubusercontent.com/1897962/214556144-6bc866eb-eb67-442e-8823-055c1b3da193.png)

After:
![Bildschirmfoto vom 2023-01-25 12-45-56](https://user-images.githubusercontent.com/1897962/214556164-8dbae9e8-7ce5-4c5c-8ede-b4f849188422.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
