### PR TITLE
Disable owner field in edit mode.

### DIFF
--- a/src/app/pages/admin/bucket/bucket-form-page/bucket-form-page.component.ts
+++ b/src/app/pages/admin/bucket/bucket-form-page/bucket-form-page.component.ts
@@ -140,7 +140,7 @@ export class BucketFormPageComponent implements OnInit, IsDirty {
           label: TEXT('Owner'),
           hint: TEXT('The owner of the bucket.'),
           value: '',
-          autofocus: editing,
+          readonly: editing,
           options: this.ownerOptions,
           validators: {
             required: true


### PR DESCRIPTION
This is to workaround https://github.com/aquarist-labs/s3gw/issues/86.

![Peek 2023-01-26 12-13](https://user-images.githubusercontent.com/1897962/214822746-1ff218c3-bdf1-4932-bb4c-71184c019217.gif)

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
