### PR TITLE
UI: Add button to copy current object browser path to the clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0]
 
+### Added
+
+- Add button to copy the current path of the object browser to the clipboard.
+
 ### Changed
 
 - Display object data more intuitively (gh#aquarist-labs/s3gw#350).

--- a/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.html
+++ b/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.html
@@ -31,7 +31,7 @@
               class="delimiter mx-1">
           {{ delimiter }}
         </span>
-        <div class="prefixes me-3">
+        <div class="prefixes me-2">
           <ng-container *ngFor="let prefixPart of prefixParts; let index = index; let last = last">
             <a class="prefix-part"
                [ngClass]="{'last': last}"
@@ -44,6 +44,12 @@
             </span>
           </ng-container>
         </div>
+        <button type="button"
+                class="btn btn-light rounded-0"
+                title="{{ 'Copy to clipboard' | transloco }}"
+                (click)="onCopyPrefixToClipboard()">
+          <i [class]="icons.copy"></i>
+        </button>
       </div>
     </s3gw-datatable-custom-top>
     <ng-template s3gw-datatable-expanded-row-template

--- a/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
+++ b/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
@@ -1,3 +1,4 @@
+import { Clipboard } from '@angular/cdk/clipboard';
 import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { AbstractControl, AsyncValidatorFn, ValidationErrors } from '@angular/forms';
 import { ActivatedRoute, Params, Router } from '@angular/router';
@@ -70,6 +71,7 @@ export class ObjectDatatablePageComponent implements OnInit {
   private firstLoadComplete = false;
 
   constructor(
+    private clipboard: Clipboard,
     private dialogService: DialogService,
     private localeDatePipe: LocaleDatePipe,
     private modalDialogService: ModalDialogService,
@@ -302,6 +304,16 @@ export class ObjectDatatablePageComponent implements OnInit {
       });
     }
     return result;
+  }
+
+  onCopyPrefixToClipboard(): void {
+    const prefix: string = this.s3BucketService.buildPrefix(this.prefixParts);
+    const success = this.clipboard.copy(prefix);
+    if (success) {
+      this.notificationService.showSuccess(TEXT('Successfully copied path to the clipboard.'));
+    } else {
+      this.notificationService.showError(TEXT('Failed to copy path to the clipboard.'));
+    }
   }
 
   isExpandableRow(): (data: DatatableData) => boolean {

--- a/src/app/shared/components/datatable/datatable.component.html
+++ b/src/app/shared/components/datatable/datatable.component.html
@@ -297,13 +297,14 @@
 </ng-template>
 
 <ng-template #copyToClipboardTpl
+             let-column="column"
              let-value="value">
   <ng-container *ngIf="value">
     <span [title]="value">{{ value }}</span>
     <i class="mdi-18px s3gw-cursor-pointer ms-1"
        [class]="icons.copy"
        title="{{ 'Copy to clipboard' | transloco }}"
-       (click)="onCopyToClipboard($event, value)">
+       (click)="onCopyToClipboard($event, value, column)">
     </i>
   </ng-container>
 </ng-template>

--- a/src/app/shared/components/datatable/datatable.component.spec.ts
+++ b/src/app/shared/components/datatable/datatable.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ToastrModule } from 'ngx-toastr';
 
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import {
@@ -23,7 +24,7 @@ describe('DatatableComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DatatableComponent],
-      imports: [ComponentsModule, TestingModule]
+      imports: [ComponentsModule, ToastrModule.forRoot(), TestingModule]
     }).compileComponents();
   });
 

--- a/src/app/shared/components/datatable/datatable.component.ts
+++ b/src/app/shared/components/datatable/datatable.component.ts
@@ -13,10 +13,13 @@ import {
   TemplateRef,
   ViewChild
 } from '@angular/core';
+import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as _ from 'lodash';
 import { Subscription, timer } from 'rxjs';
 
 import { Throttle } from '~/app/functions.helper';
+import { format } from '~/app/functions.helper';
+import { translate } from '~/app/i18n.helper';
 import { DatatableExpandedRowTemplateDirective } from '~/app/shared/directives/datatable-expanded-row-template.directive';
 import { Icon } from '~/app/shared/enum/icon.enum';
 import { Datatable } from '~/app/shared/models/datatable.interface';
@@ -25,6 +28,7 @@ import {
   DatatableColumn
 } from '~/app/shared/models/datatable-column.type';
 import { DatatableData } from '~/app/shared/models/datatable-data.type';
+import { NotificationService } from '~/app/shared/services/notification.service';
 import { UserLocalStorageService } from '~/app/shared/services/user-local-storage.service';
 
 export enum SortDirection {
@@ -167,6 +171,7 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy {
   constructor(
     private clipboard: Clipboard,
     private ngZone: NgZone,
+    private notificationService: NotificationService,
     private userLocalStorageService: UserLocalStorageService
   ) {}
 
@@ -379,9 +384,22 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy {
     this.updateSelection();
   }
 
-  onCopyToClipboard(event: Event, value: any): void {
+  onCopyToClipboard(event: Event, value: any, column: DatatableColumn): void {
     event.stopPropagation();
-    this.clipboard.copy(value);
+    const success = this.clipboard.copy(value);
+    if (success) {
+      this.notificationService.showSuccess(
+        format(TEXT('Successfully copied "{{ text }}" to the clipboard.'), {
+          text: translate(column.name)
+        })
+      );
+    } else {
+      this.notificationService.showError(
+        format(TEXT('Failed to copy "{{ text }}" to the clipboard.'), {
+          text: translate(column.name)
+        })
+      );
+    }
   }
 
   clearSearchFilter(): void {

--- a/src/app/shared/components/declarative-form/declarative-form.component.ts
+++ b/src/app/shared/components/declarative-form/declarative-form.component.ts
@@ -291,7 +291,7 @@ export class DeclarativeFormComponent implements AfterViewInit, DeclarativeForm,
     const text = this.formGroup?.get(field.name!)?.value;
     const success = this.clipboard.copy(text);
     if (success) {
-      this.notificationService.showSuccess(TEXT('Copied text to the clipboard successfully.'));
+      this.notificationService.showSuccess(TEXT('Successfully copied text to the clipboard.'));
     } else {
       this.notificationService.showError(TEXT('Failed to copy text to the clipboard.'));
     }


### PR DESCRIPTION
Additionally improve the copy to clipboard feature of the datatable.

![Peek 2023-03-14 12-39](https://user-images.githubusercontent.com/1897962/224990047-67dfb6c9-f665-4386-b149-366c85760da7.gif)

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
