### PR TITLE
Remove useless getObjectRetention call …

### DIFF
--- a/src/app/shared/services/api/s3-bucket.service.ts
+++ b/src/app/shared/services/api/s3-bucket.service.ts
@@ -1062,11 +1062,6 @@ export class S3BucketService {
     return forkJoin({
       object: this.headObject(bucket, key, undefined, credentials),
       tagging: this.getObjectTagging(bucket, key, credentials),
-      // Get the object's retention and legal hold settings in a separate
-      // request because there seems to be a bug in the headObject function,
-      // check out https://github.com/aws/aws-sdk-js/issues/4362 for more
-      // details.
-      retention: this.getObjectRetention(bucket, key, credentials),
       legalHold: this.getObjectLegalHold(bucket, key, credentials)
     }).pipe(
       map((resp) => {
@@ -1074,8 +1069,6 @@ export class S3BucketService {
           ...resp.object,
           ...resp.tagging,
           /* eslint-disable @typescript-eslint/naming-convention */
-          ObjectLockMode: resp.retention.Retention?.Mode,
-          ObjectLockRetainUntilDate: resp.retention.Retention?.RetainUntilDate,
           ObjectLockLegalHoldStatus: resp.legalHold.LegalHold?.Status
           /* eslint-enable @typescript-eslint/naming-convention */
         };


### PR DESCRIPTION
… because the information is delivered by the headObject call. The problem here was that the Traefic ingress is incorrect configured in regards to the `Access-Control-Expose-Headers` header. Because of that the headers `X-Amz-Object-Lock-Mode` and `X-Amz-Object-Lock-Retain-Until-Date` where not included in the response.

Related to: https://github.com/aquarist-labs/s3gw/issues/410 and https://github.com/aquarist-labs/s3gw-charts/pull/89


# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
