### PR TITLE
ui: add backend

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,20 +1,19 @@
 ---
-name: Lint & Unit Tests for S3GW UI
+name: Lint & Unit Tests for s3gw UI
 on:
   push:
     branches:
-      - '*'
+      - "*"
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   frontend-lint:
     runs-on: ubuntu-latest
 
     steps:
-
-      - name: Checkout S3GW UI
+      - name: Checkout s3gw UI
         uses: actions/checkout@v3
 
       - name: Set up node.js
@@ -36,8 +35,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-      - name: Checkout S3GW UI
+      - name: Checkout s3gw UI
         uses: actions/checkout@v3
 
       - name: Set up node.js
@@ -54,3 +52,63 @@ jobs:
       - name: Run Unit Tests
         working-directory: src/frontend
         run: npm run test:ci
+
+  backend-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout s3gw UI
+        uses: actions/checkout@v3
+
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Check code format
+        working-directory: src
+        run: tox -e lint
+
+  backend-types:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout s3gw UI
+        uses: actions/checkout@v3
+
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Check types
+        working-directory: src
+        run: tox -e types
+
+  backend-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout s3gw UI
+        uses: actions/checkout@v3
+
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run tests
+        working-directory: src
+        run: tox -e py310

--- a/src/.coveragerc
+++ b/src/.coveragerc
@@ -2,4 +2,3 @@
 omit =
   backend/tests/*
   .tox/*
-  *__init__.py

--- a/src/.coveragerc
+++ b/src/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+  backend/tests/*
+  .tox/*
+  *__init__.py

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,7 @@
 .tox/
 venv/
 **__pycache__**
+.coverage
+coverage.xml
+.pytest_cache
+htmlcov/

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,3 @@
+.tox/
+venv/
+**__pycache__**

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -82,6 +82,14 @@ $ tox -e py310 -- backend/tests/api/test_api.py
 $ tox -e py310 -- backend/tests/api/test_api.py::test_s3server
 ```
 
+There is one additional testing environment, not recommended unless for very
+specific purposes: `py310-with-s3gw`. This environment is not part of `tox`'s
+list of environments, and will only be run if called explicitly. It is meant to
+run against a live `s3gw` instance running at `http://127.0.0.1:7480`, to test
+both the semantic compatibility of our operations with `s3gw`, given the mock
+server we use for testing (provided by `moto`) is sometimes not exactly true to
+S3 semantics.
+
 ## Developing
 
 We rely on Python 3.10.

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -1,0 +1,202 @@
+# s3gw-ui backend
+
+These are notes for developers. Users should rely on [s3gw documentation][1].
+
+[1]: https://s3gw-docs.readthedocs.io/en/latest/?badge=latest
+
+## Setup
+
+```shell
+$ cd src/
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt -r requirements-dev.txt
+```
+
+## Running
+
+### Preparing the UI
+
+Before running the backend, the frontend needs to be built. Otherwise, an error
+will be thrown. It is recommended to follow the instructions for the frontend,
+but a quick gist of the process is as follows:
+
+```shell
+$ cd src/frontend/
+$ npm ci
+$ npx ng build
+```
+
+In reality, the backend only requires the `dist/s3gw-ui/` directory to exist.
+For the lazy, creating said directory should be enough.
+
+### Running the backend
+
+Running the backend solely requires running the `s3gw_ui_backend.py` script.
+
+```shell
+$ cd src/
+
+$ python3 ./s3gw_ui_backend.py
+
+# or
+
+$ S3GW_DEBUG=1 python3 ./s3gw_ui_backend.py
+```
+
+To run with debug mode enabled, specify `S3GW_DEBUG=1`. Note that this will
+result in a lot more information than just the backend's debug information. It
+may include backtraces from exceptions thrown by used libraries (such as
+`aiohttp`) which are harmless, assuming they are caught and handled by the
+calling code.
+
+## Testing
+
+We rely on `tox` to orchestrate and manage our tests. There are three different
+checks: `py310`, for `pytest` tests; `lint`, for code formatting checks using
+`black`; and `types`, for static type checking using `pyright`.
+
+`tox` needs to be run from the `src/` directory, where `tox.ini` is present.
+
+```shell
+$ cd src/
+$ tox
+```
+
+Individual `tox` environments can also be run.
+
+```shell
+$ tox -e py310 # for pytest only, for instance
+$ tox -e types # for type checking only
+$ tox -e lint  # for linting with black and isort
+```
+
+To run a single `pytest` test file, one should rely on `tox` instead of `pytest`
+directly, as `tox` sets up its own testing environment.
+
+```shell
+$ tox -e py310 -- backend/tests/api/test_api.py
+
+# or, for only a testing function within a single test file,
+
+$ tox -e py310 -- backend/tests/api/test_api.py::test_s3server
+```
+
+## Developing
+
+We rely on Python 3.10.
+
+### Coding Style
+
+Code is formatted by `black`, with the exception of lines being 80 characters in
+length.
+
+Additionally, imports must be sorted according to `isort`'s format, with a
+maximum length of 80 characters.
+
+Individual settings for both can be found in `pyproject.toml`.
+
+### Type Checking
+
+We rely on [`pyright`][2] for static type checking. Using type hints is not only
+encouraged, it is mandatory, except when the type is rather obvious and in
+exceptional circumstances. For more information on type hints, please refer to
+the [Python documentation][3].
+
+`pyright` is run in `strict` type checking mode. This means with all
+type-checking diagnostic rules enabled. We know this may sometimes be painful,
+but it is worth it in the long term. If needed, and solely when the benefit
+outweighs the drawbacks, rules can be disabled on a per-file or per-line basis; e.g.,
+
+```python
+# pyright: reportMissingTypeStubs=false
+
+import something.without.stubs
+
+...
+
+problematic_line_1()  # pyright: ignore
+problematic_line_2()  # pyright: ignore [reportGeneralTypeIssues]
+
+...
+```
+
+`pyright`'s documentation includes further information on
+[diagnostic suppression][4] and on [diagnostic rules][5].
+
+[2]: https://github.com/microsoft/pyright
+[3]: https://docs.python.org/3.10/library/typing.html
+[4]: https://microsoft.github.io/pyright/#/comments?id=comments
+[5]: https://microsoft.github.io/pyright/#/configuration?id=diagnostic-rule-defaults
+
+### Monitoring coverage
+
+When `pytests` is run (e.g., via `tox -e py310`), a code coverage report is
+generated for all python files, excluding tests and type stubs. This report will
+be shown to the terminal, written in `coverage.xml`, and also written to
+`htmlcov/` as an `html` report.
+
+The latter is more informative than the terminal and the `xml` versions, because
+it will allow to check, per-file, the lines that are being covered.
+
+A simple way to properly view this report is by serving this directory via
+`nginx`; e.g.,
+
+```
+podman run -d --replace --name s3gw-ui-backend-cov \
+  -p 31337:80 \
+  -v /home/joao/code/aquarist-labs/s3gw-ui.git/src/htmlcov:/usr/share/nginx/html \
+  docker.io/library/nginx:latest || exit 1
+```
+
+Accessing the host at port `31337` will now provide the coverage report. Should
+the server be inaccessible, and a firewall be in place, the port may need to be opened.
+
+### vscode
+
+vscode users may want to configure their workspace to perform most, if not all,
+of these actions automatically.
+
+We recommend using the official Python extension, with Pylance as the language
+server, and then setting the following as the workspace configuration:
+
+```json
+{
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": ["--line-length", "80"],
+  "isort.check": true,
+  "isort.args": ["--profile", "black"],
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
+  },
+  "python.analysis.typeCheckingMode": "strict"
+}
+```
+
+## Contributing
+
+All submitted patches need to be GPG signed, carry a Developer's Certificate of
+Origin, and be accompanied by unit tests.
+
+It is expected that code coverage either remain the same or be improved with
+every new patch.
+
+## LICENSE
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+Copywrite is owned by the individual contributors, except when mentioned
+otherwise.

--- a/src/backend/api/__init__.py
+++ b/src/backend/api/__init__.py
@@ -88,6 +88,10 @@ class S3GWClient:
                     status_code=status.HTTP_501_NOT_IMPLEMENTED,
                     detail="SSL not supported",
                 )
+            except HTTPException as e:
+                # probably an error raised by yielded client context; lets
+                # propagate it.
+                raise e
             except Exception as e:
                 logger.error(f"Unknown error: {e}")
                 logger.error(f"  exception: {type(e)}")

--- a/src/backend/api/__init__.py
+++ b/src/backend/api/__init__.py
@@ -51,11 +51,11 @@ class S3GWClient:
         self._secret_key = secret_key
 
     @contextlib.asynccontextmanager
-    async def conn(self) -> AsyncGenerator[S3Client, None]:
+    async def conn(self, attempts: int = 1) -> AsyncGenerator[S3Client, None]:
         """
         Yields an `aiobotocore's S3Client` instance, that can be used to
         perform operations against an S3-compatible server. In case of failure,
-        the operation does not perform more attempts.
+        by default, the operation only performs one attempt.
 
         This context manager will catch most exceptions thrown by the
         `S3Client`'s operations, and convert them to `fastapi.HTTPException`.
@@ -68,7 +68,7 @@ class S3GWClient:
             aws_secret_access_key=self._secret_key,
             config=S3Config(
                 retries={
-                    "max_attempts": 1,
+                    "max_attempts": attempts,
                     "mode": "standard",
                 }
             ),

--- a/src/backend/api/__init__.py
+++ b/src/backend/api/__init__.py
@@ -1,0 +1,164 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import re
+from typing import Annotated, Any, AsyncGenerator, Dict, Tuple, cast
+
+from aiobotocore.session import AioSession
+from botocore.config import Config as S3Config
+from botocore.exceptions import ClientError, EndpointConnectionError, SSLError
+from fastapi import Header, HTTPException, status
+from fastapi.logger import logger
+from types_aiobotocore_s3.client import S3Client
+
+
+class S3GWClient:
+    """
+    Represents a client connection to an s3gw server.
+
+    A connection is not opened by this class. Instead, a client is created when
+    requesting a connection via the `conn()` context manager, and the connection
+    is handled by the `aiobotocore's S3Client` class that is returned.
+    """
+
+    _endpoint: str
+    _access_key: str
+    _secret_key: str
+
+    def __init__(self, endpoint: str, access_key: str, secret_key: str) -> None:
+        """
+        Creates a new `S3GWClient` instance.
+
+        Arguments:
+        * `endpoint`: the URL where the server is expected to be at.
+        * `access_key`: the user's `access key`.
+        * `secret_key`: the user's `secret access key`.
+        """
+        self._endpoint = endpoint
+        self._access_key = access_key
+        self._secret_key = secret_key
+
+    @contextlib.asynccontextmanager
+    async def conn(self) -> AsyncGenerator[S3Client, None]:
+        """
+        Yields an `aiobotocore's S3Client` instance, that can be used to
+        perform operations against an S3-compatible server. In case of failure,
+        the operation does not perform more attempts.
+
+        This context manager will catch most exceptions thrown by the
+        `S3Client`'s operations, and convert them to `fastapi.HTTPException`.
+        """
+        session = AioSession()
+        async with session.create_client(
+            "s3",
+            endpoint_url=self._endpoint,
+            aws_access_key_id=self._access_key,
+            aws_secret_access_key=self._secret_key,
+            config=S3Config(
+                retries={
+                    "max_attempts": 1,
+                    "mode": "standard",
+                }
+            ),
+        ) as client:
+            try:
+                yield cast(S3Client, client)
+            except ClientError as e:
+                (code, msg) = decode_client_error(e)
+                raise HTTPException(status_code=code, detail=msg)
+            except EndpointConnectionError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="Endpoint not found",
+                )
+            except SSLError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                    detail="SSL not supported",
+                )
+            except Exception as e:
+                logger.error(f"Unknown error: {e}")
+                logger.error(f"  exception: {type(e)}")
+                raise HTTPException(status_code=500)
+
+
+def decode_client_error(e: ClientError) -> Tuple[int, str]:
+    """
+    Returns a tuple of `(status_code, error_message)` according to the
+    `botocore's ClientError` exception thas is passed as an argument.
+    """
+    status_code = 500
+    msg = "Unknown Error"
+
+    if "Error" in e.response:
+        if "Code" in e.response["Error"]:
+            if e.response["Error"]["Code"] == "InvalidAccessKeyId":
+                msg = "Invalid credentials"
+                status_code = status.HTTP_401_UNAUTHORIZED
+
+    return (status_code, msg)
+
+
+async def s3gw_client(
+    x_s3gw_endpoint: Annotated[str, Header()],
+    x_s3gw_credentials: Annotated[str, Header()],
+) -> S3GWClient:
+    """
+    To be used for FastAPI's dependency injection, reads the request's HTTP
+    headers for s3gw's endpoint and user credentials, returning an `S3GWClient`
+    class instance.
+    """
+    m = re.fullmatch(
+        r"https?://[\w.-]+(?:\.[\w]+)?(?::\d+)?/?", x_s3gw_endpoint
+    )
+    if m is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Malformed S3 endpoint URL",
+        )
+
+    # credentials follow the format 'access_key:secret_key'
+    m = re.fullmatch(r"^([\w+/=]+):([\w+/=]+)$", x_s3gw_credentials)
+    if m is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing of malformed credentials",
+        )
+
+    assert len(m.groups()) == 2
+    access, secret = m.group(1), m.group(2)
+    assert len(access) > 0 and len(secret) > 0
+    return S3GWClient(x_s3gw_endpoint, access, secret)
+
+
+def s3gw_client_responses() -> Dict[int | str, Dict[str, Any]]:
+    """
+    Used to populate FastAPI's OpenAPI's method documentation, returns a
+    dictionary containing the several error responses raised by `s3gw_client()`.
+    """
+    return {
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials",
+        },
+        status.HTTP_502_BAD_GATEWAY: {
+            "description": "Endpoint not found",
+        },
+        status.HTTP_501_NOT_IMPLEMENTED: {
+            "description": "SSL not supported",
+        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "description": "Unexpected error",
+        },
+    }

--- a/src/backend/api/bucket.py
+++ b/src/backend/api/bucket.py
@@ -1,0 +1,44 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated, List
+
+from fastapi import Depends
+from fastapi.routing import APIRouter
+from pydantic import BaseModel
+from types_aiobotocore_s3.type_defs import ListBucketsOutputTypeDef
+
+from backend.api import S3GWClient, s3gw_client, s3gw_client_responses
+
+router = APIRouter(prefix="/bucket")
+
+S3GWClientDep = Annotated[S3GWClient, Depends(s3gw_client)]
+
+
+class BucketListResponse(BaseModel):
+    buckets: List[str]
+
+
+@router.get(
+    "/list",
+    response_model=BucketListResponse,
+    responses=s3gw_client_responses(),
+)
+async def get_bucket_list(conn: S3GWClientDep) -> BucketListResponse:
+    async with conn.conn() as s3:
+        bucket_lst: ListBucketsOutputTypeDef = await s3.list_buckets()
+        buckets = [b["Name"] for b in bucket_lst["Buckets"]]
+        res = BucketListResponse(buckets=buckets)
+
+    return res

--- a/src/backend/logging.py
+++ b/src/backend/logging.py
@@ -1,0 +1,87 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging.config
+import os
+from typing import Any, Dict, List
+
+
+def setup_logging() -> None:
+    lvl = "INFO" if not os.getenv("S3GW_DEBUG") else "DEBUG"
+    logfile = os.getenv("S3GW_LOG_FILE")
+    _setup_logging(lvl, logfile)
+
+
+def _setup_logging(
+    console_level: str,
+    log_file: str | None,
+) -> None:
+    file_handler: Dict[str, Any] | None = None
+
+    if log_file is not None:
+        file_handler = {
+            "level": "DEBUG",
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "simple",
+            "filename": log_file,
+            "maxBytes": 10485760,
+            "backupCount": 1,
+        }
+
+    cfg: Dict[str, Any] = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "simple": {
+                "format": (
+                    "[%(levelname)-5s] %(asctime)s -- %(module)s -- %(message)s"
+                ),
+                "datefmt": "%Y-%m-%dT%H:%M:%S",
+            },
+            "colorized": {
+                "()": "uvicorn.logging.ColourizedFormatter",
+                "format": (
+                    "%(levelprefix)s %(asctime)s -- %(module)s -- %(message)s"
+                ),
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+            },
+        },
+        "handlers": {
+            "console": {
+                "level": console_level,
+                "class": "logging.StreamHandler",
+                "formatter": "colorized",
+            },
+        },
+    }
+
+    handlers: List[str] = ["console"]
+
+    if file_handler is not None:
+        cfg["handlers"]["log_file"] = file_handler
+        handlers.append("log_file")
+
+    cfg["loggers"] = {
+        "uvicorn": {
+            "level": "DEBUG",
+            "handlers": handlers,
+            "propagate": "no",
+        }
+    }
+    cfg["root"] = {
+        "level": "DEBUG",
+        "handlers": handlers,
+    }
+
+    logging.config.dictConfig(cfg)

--- a/src/backend/tests/api/test_api.py
+++ b/src/backend/tests/api/test_api.py
@@ -19,7 +19,7 @@ from fastapi import HTTPException, status
 from backend.api import S3GWClient, decode_client_error, s3gw_client
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_s3gw_conn_malformed_url() -> None:
     creds = "foo:bar"
     bad_urls = [
@@ -43,7 +43,7 @@ async def test_s3gw_conn_malformed_url() -> None:
         assert error_found
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_s3gw_conn_malformed_creds() -> None:
     url = "https://foo.bar:123"
     bad_creds = [
@@ -70,7 +70,7 @@ async def test_s3gw_conn_malformed_creds() -> None:
         assert error_found
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_s3gw_conn_success() -> None:
     url = "https://foo.bar:123"
     creds = "foo:bar"
@@ -79,7 +79,7 @@ async def test_s3gw_conn_success() -> None:
     assert client is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_s3gw_client_bad_endpoint() -> None:
     s3gw_client = S3GWClient("http://foo.bar", "asd", "qwe")
 
@@ -94,7 +94,7 @@ async def test_s3gw_client_bad_endpoint() -> None:
     assert raised
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_s3server(s3_server: str) -> None:
     s3gw_client = S3GWClient(s3_server, "foo", "bar")
     async with s3gw_client.conn() as client:

--- a/src/backend/tests/api/test_api.py
+++ b/src/backend/tests/api/test_api.py
@@ -1,0 +1,126 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from botocore.exceptions import ClientError
+from fastapi import HTTPException, status
+
+from backend.api import S3GWClient, decode_client_error, s3gw_client
+
+
+@pytest.mark.asyncio
+async def test_s3gw_conn_malformed_url() -> None:
+    creds = "foo:bar"
+    bad_urls = [
+        "something://foo.bar:123",
+        "http:/foo.bar:123",
+        "http//foo.bar:123",
+        "httpp://foo.bar:123",
+        "https://foo+bar:123",
+        "https://foo.bar:123a",
+    ]
+
+    for url in bad_urls:
+        error_found = False
+        try:
+            await s3gw_client(url, creds)
+        except HTTPException as e:
+            assert e.status_code == status.HTTP_400_BAD_REQUEST
+            error_found = True
+        if not error_found:
+            print(f"test failed at '{url}'")
+        assert error_found
+
+
+@pytest.mark.asyncio
+async def test_s3gw_conn_malformed_creds() -> None:
+    url = "https://foo.bar:123"
+    bad_creds = [
+        "foo",
+        "foo@bar",
+        ":bar",
+        "foo:",
+        "foo : bar",
+        ": bar",
+        " ",
+        "",
+        "foo :",
+    ]
+
+    for creds in bad_creds:
+        error_found = False
+        try:
+            await s3gw_client(url, creds)
+        except HTTPException as e:
+            assert e.status_code == status.HTTP_401_UNAUTHORIZED
+            error_found = True
+        if not error_found:
+            print(f"test failed at '{creds}'")
+        assert error_found
+
+
+@pytest.mark.asyncio
+async def test_s3gw_conn_success() -> None:
+    url = "https://foo.bar:123"
+    creds = "foo:bar"
+
+    client = await s3gw_client(url, creds)
+    assert client is not None
+
+
+@pytest.mark.asyncio
+async def test_s3gw_client_bad_endpoint() -> None:
+    s3gw_client = S3GWClient("http://foo.bar", "asd", "qwe")
+
+    raised = False
+    try:
+        async with s3gw_client.conn() as client:
+            await client.list_buckets()
+    except HTTPException as e:
+        assert e.status_code == status.HTTP_502_BAD_GATEWAY
+        raised = True
+
+    assert raised
+
+
+@pytest.mark.asyncio
+async def test_s3server(s3_server: str) -> None:
+    s3gw_client = S3GWClient(s3_server, "foo", "bar")
+    async with s3gw_client.conn() as client:
+        lst = await client.list_buckets()
+        assert "Buckets" in lst
+        assert len(lst["Buckets"]) == 0
+        await client.create_bucket(Bucket="foo")
+        lst = await client.list_buckets()
+        assert "Buckets" in lst
+        assert len(lst["Buckets"]) == 1
+        buckets = [x["Name"] for x in lst["Buckets"]]
+        assert "foo" in buckets
+
+
+def test_decode_client_error() -> None:
+    error = ClientError(
+        error_response={
+            "Error": {"Code": "InvalidAccessKeyId", "Message": "foo bar"}
+        },
+        operation_name="TestOperation",
+    )
+    (code, msg) = decode_client_error(error)
+    assert code == status.HTTP_401_UNAUTHORIZED
+    assert msg == "Invalid credentials"
+
+    error = ClientError(error_response={}, operation_name="TestOperation2")
+    (code, msg) = decode_client_error(error)
+    assert code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert msg == "Unknown Error"

--- a/src/backend/tests/api/test_bucket.py
+++ b/src/backend/tests/api/test_bucket.py
@@ -17,7 +17,7 @@ import pytest
 from backend.api import S3GWClient, bucket
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_bucket_list(s3_server: str) -> None:
     s3gw_client = S3GWClient(s3_server, "foo", "bar")
 

--- a/src/backend/tests/api/test_bucket.py
+++ b/src/backend/tests/api/test_bucket.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from types_aiobotocore_s3.client import Exceptions
 
 from backend.api import S3GWClient, bucket
 
@@ -28,3 +29,20 @@ async def test_api_bucket_list(s3_client: S3GWClient) -> None:
     assert "foo" in res.buckets
     assert "bar" in res.buckets
     assert len(res.buckets) == 2
+
+
+@pytest.mark.anyio
+async def test_api_bucket_create(s3_client: S3GWClient) -> None:
+    await bucket.bucket_create(s3_client, "asdasd", enable_object_locking=False)
+
+    raised = False
+    try:
+        await bucket.bucket_create(
+            s3_client, "asdasd", enable_object_locking=False
+        )
+    except Exceptions.BucketAlreadyExists:
+        raised = True
+
+    # everything seems to point to creating an already existing bucket being an
+    # idempotent operation, returning success.
+    assert not raised

--- a/src/backend/tests/api/test_bucket.py
+++ b/src/backend/tests/api/test_bucket.py
@@ -18,15 +18,13 @@ from backend.api import S3GWClient, bucket
 
 
 @pytest.mark.anyio
-async def test_api_bucket_list(s3_server: str) -> None:
-    s3gw_client = S3GWClient(s3_server, "foo", "bar")
-
+async def test_api_bucket_list(s3_client: S3GWClient) -> None:
     # create a couple of buckets
-    async with s3gw_client.conn() as client:
+    async with s3_client.conn() as client:
         await client.create_bucket(Bucket="foo")
         await client.create_bucket(Bucket="bar")
 
-    res: bucket.BucketListResponse = await bucket.get_bucket_list(s3gw_client)
+    res: bucket.BucketListResponse = await bucket.get_bucket_list(s3_client)
     assert "foo" in res.buckets
     assert "bar" in res.buckets
     assert len(res.buckets) == 2

--- a/src/backend/tests/api/test_bucket.py
+++ b/src/backend/tests/api/test_bucket.py
@@ -1,0 +1,32 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from backend.api import S3GWClient, bucket
+
+
+@pytest.mark.asyncio
+async def test_api_bucket_list(s3_server: str) -> None:
+    s3gw_client = S3GWClient(s3_server, "foo", "bar")
+
+    # create a couple of buckets
+    async with s3gw_client.conn() as client:
+        await client.create_bucket(Bucket="foo")
+        await client.create_bucket(Bucket="bar")
+
+    res: bucket.BucketListResponse = await bucket.get_bucket_list(s3gw_client)
+    assert "foo" in res.buckets
+    assert "bar" in res.buckets
+    assert len(res.buckets) == 2

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -15,7 +15,9 @@
 from typing import AsyncGenerator
 
 import pytest
-from mock_server import MotoService
+
+from backend.api import S3GWClient
+from backend.tests.mock_server import MotoService
 
 
 @pytest.fixture
@@ -27,3 +29,8 @@ def anyio_backend():
 async def s3_server() -> AsyncGenerator[str, None]:
     async with MotoService("s3") as svc:
         yield svc.endpoint_url
+
+
+@pytest.fixture
+async def s3_client(s3_server: str) -> AsyncGenerator[S3GWClient, None]:
+    yield S3GWClient(s3_server, "foo", "bar")

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import AsyncGenerator
+
+import pytest_asyncio
+from mock_server import MotoService
+
+
+@pytest_asyncio.fixture  # type: ignore
+async def s3_server() -> AsyncGenerator[str, None]:
+    async with MotoService("s3") as svc:
+        yield svc.endpoint_url

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -14,11 +14,16 @@
 
 from typing import AsyncGenerator
 
-import pytest_asyncio
+import pytest
 from mock_server import MotoService
 
 
-@pytest_asyncio.fixture  # type: ignore
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
 async def s3_server() -> AsyncGenerator[str, None]:
     async with MotoService("s3") as svc:
         yield svc.endpoint_url

--- a/src/backend/tests/mock_server.py
+++ b/src/backend/tests/mock_server.py
@@ -1,0 +1,109 @@
+# from https://github.com/aio-libs/aiobotocore
+#  commit 8d9d71afa51fc7a442d34f26165a6a1975bd9b40
+#  license Apache-2.0
+#  copyright held by the original authors
+#
+# For additional changes,
+#  Copyright 2023 SUSE LLC
+#  Licensed under the Apache License, Version 2.0.
+
+# type: ignore
+
+import asyncio
+import multiprocessing
+
+# Third Party
+import aiohttp
+import aiohttp.web
+import pytest
+from aiohttp.web import StreamResponse
+
+# aiobotocore
+from moto_server import MotoService, get_free_tcp_port, host
+
+_proxy_bypass = {
+    "http": None,
+    "https": None,
+}
+
+
+# This runs in a subprocess for a variety of reasons
+# 1) early versions of python 3.5 did not correctly set one thread per run loop
+# 2) aiohttp uses get_event_loop instead of using the passed in run loop
+# 3) aiohttp shutdown can be hairy
+class AIOServer(multiprocessing.Process):
+    """
+    This is a mock AWS service which will 5 seconds before returning
+    a response to test socket timeouts.
+    """
+
+    endpoint_url: str
+
+    def __init__(self):
+        super().__init__(target=self._run)
+        self._loop = None
+        self._port = get_free_tcp_port(True)
+        self.endpoint_url = f"http://{host}:{self._port}"
+        self.daemon = True  # die when parent dies
+
+    def _run(self):
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        app = aiohttp.web.Application()
+        app.router.add_route("*", "/ok", self.ok)
+        app.router.add_route("*", "/{anything:.*}", self.stream_handler)
+
+        try:
+            aiohttp.web.run_app(
+                app, host=host, port=self._port, handle_signals=False
+            )
+        except BaseException:
+            pytest.fail("unable to start and connect to aiohttp server")
+            raise
+
+    async def __aenter__(self):
+        self.start()
+        await self._wait_until_up()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        try:
+            self.terminate()
+        except BaseException:
+            pytest.fail("Unable to shut down server")
+            raise
+
+    @staticmethod
+    async def ok(request):
+        return aiohttp.web.Response()
+
+    async def stream_handler(self, request):
+        # Without the Content-Type, most (all?) browsers will not render
+        # partially downloaded content. Note, the response type is
+        # StreamResponse not Response.
+        resp = StreamResponse(
+            status=200, reason="OK", headers={"Content-Type": "text/html"}
+        )
+
+        await resp.prepare(request)
+        await asyncio.sleep(5)
+        await resp.drain()
+        return resp
+
+    async def _wait_until_up(self):
+        async with aiohttp.ClientSession() as session:
+            for i in range(0, 30):
+                if self.exitcode is not None:
+                    pytest.fail("unable to start/connect to aiohttp server")
+                    return
+
+                try:
+                    # we need to bypass the proxies due to monkey patches
+                    await session.get(self.endpoint_url + "/ok", timeout=0.5)
+                    return
+                except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
+                    await asyncio.sleep(0.5)
+                except BaseException:
+                    pytest.fail("unable to start/connect to aiohttp server")
+                    raise
+
+        pytest.fail("unable to start and connect to aiohttp server")

--- a/src/backend/tests/moto_server.py
+++ b/src/backend/tests/moto_server.py
@@ -1,0 +1,158 @@
+# from https://github.com/aio-libs/aiobotocore
+#  commit 8d9d71afa51fc7a442d34f26165a6a1975bd9b40
+#  license Apache-2.0
+#
+# For additional changes,
+#  Copyright 2023 SUSE LLC
+#  Licensed under the Apache License, Version 2.0.
+
+# type: ignore
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+import socket
+import threading
+import time
+from typing import Dict
+
+# Third Party
+import aiohttp
+import moto.server
+import werkzeug.serving
+
+host = "127.0.0.1"
+
+_PYCHARM_HOSTED = os.environ.get("PYCHARM_HOSTED") == "1"
+_CONNECT_TIMEOUT = 90 if _PYCHARM_HOSTED else 10
+
+
+def get_free_tcp_port(release_socket: bool = False):
+    sckt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sckt.bind((host, 0))
+    addr, port = sckt.getsockname()
+    if release_socket:
+        sckt.close()
+        return port
+
+    return sckt, port
+
+
+class MotoService:
+    """Will Create MotoService.
+    Service is ref-counted so there will only be one per process. Real Service will
+    be returned by `__aenter__`."""
+
+    _services: Dict[str, MotoService] = dict()  # {name: instance}
+
+    def __init__(self, service_name: str, port: int = None, ssl: bool = False):
+        self._service_name = service_name
+
+        if port:
+            self._socket = None
+            self._port = port
+        else:
+            self._socket, self._port = get_free_tcp_port()
+
+        self._thread = None
+        self._logger = logging.getLogger("MotoService")
+        self._refcount = None
+        self._ip_address = host
+        self._server = None
+        self._ssl_ctx = (
+            werkzeug.serving.generate_adhoc_ssl_context() if ssl else None
+        )
+        self._schema = "http" if not self._ssl_ctx else "https"
+
+    @property
+    def endpoint_url(self) -> str:
+        return f"{self._schema}://{self._ip_address}:{self._port}"
+
+    def __call__(self, func):
+        async def wrapper(*args, **kwargs):
+            await self._start()
+            try:
+                result = await func(*args, **kwargs)
+            finally:
+                await self._stop()
+            return result
+
+        functools.update_wrapper(wrapper, func)
+        wrapper.__wrapped__ = func
+        return wrapper
+
+    async def __aenter__(self):
+        svc = self._services.get(self._service_name)
+        if svc is None:
+            self._services[self._service_name] = self
+            self._refcount = 1
+            await self._start()
+            return self
+        else:
+            svc._refcount += 1
+            return svc
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._refcount -= 1
+
+        if self._socket:
+            self._socket.close()
+            self._socket = None
+
+        if self._refcount == 0:
+            del self._services[self._service_name]
+            await self._stop()
+
+    def _server_entry(self):
+        self._main_app = moto.server.DomainDispatcherApplication(
+            moto.server.create_backend_app, service=self._service_name
+        )
+        self._main_app.debug = True
+
+        if self._socket:
+            self._socket.close()  # release right before we use it
+            self._socket = None
+
+        self._server = werkzeug.serving.make_server(
+            self._ip_address,
+            self._port,
+            self._main_app,
+            True,
+            ssl_context=self._ssl_ctx,
+        )
+        self._server.serve_forever()
+
+    async def _start(self):
+        self._thread = threading.Thread(target=self._server_entry, daemon=True)
+        self._thread.start()
+
+        async with aiohttp.ClientSession() as session:
+            start = time.time()
+
+            while time.time() - start < 10:
+                if not self._thread.is_alive():
+                    break
+
+                try:
+                    # we need to bypass the proxies due to monkeypatches
+                    async with session.get(
+                        self.endpoint_url + "/static",
+                        timeout=_CONNECT_TIMEOUT,
+                        ssl=False,
+                    ):
+                        pass
+                    break
+                except (asyncio.TimeoutError, aiohttp.ClientConnectionError):
+                    await asyncio.sleep(0.5)
+            else:
+                await self._stop()  # pytest.fail doesn't call stop_process
+                raise Exception(f"Can not start service: {self._service_name}")
+
+    async def _stop(self):
+        if self._server:
+            self._server.shutdown()
+
+        self._thread.join()

--- a/src/backend/tests/test_logging.py
+++ b/src/backend/tests/test_logging.py
@@ -1,0 +1,115 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Any, Dict
+
+from pytest_mock import MockerFixture
+
+import backend.logging
+
+
+def test_setup_logging(mocker: MockerFixture) -> None:
+    called_basic = False
+    called_debug = False
+    called_with_file = False
+
+    def mock_setup_logging_basic(lvl: str, logfile: str | None) -> None:
+        nonlocal called_basic
+        called_basic = True
+        assert lvl == "INFO"
+        assert logfile is None
+
+    def mock_setup_logging_debug(lvl: str, logfile: str | None) -> None:
+        nonlocal called_debug
+        called_debug = True
+        assert lvl == "DEBUG"
+        assert logfile is None
+
+    def mock_setup_logging_with_file(lvl: str, logfile: str | None) -> None:
+        nonlocal called_with_file
+        called_with_file = True
+        assert lvl == "INFO"
+        assert logfile is not None
+        assert logfile == "foo"
+
+    mocker.patch("backend.logging._setup_logging", new=mock_setup_logging_basic)
+    backend.logging.setup_logging()
+    assert called_basic
+
+    mocker.patch("backend.logging._setup_logging", new=mock_setup_logging_debug)
+    bak_environ = os.environ.copy()
+    os.environ["S3GW_DEBUG"] = "1"
+    backend.logging.setup_logging()
+    assert called_debug
+
+    mocker.patch(
+        "backend.logging._setup_logging", new=mock_setup_logging_with_file
+    )
+    os.environ = bak_environ
+    os.environ["S3GW_LOG_FILE"] = "foo"
+    backend.logging.setup_logging()
+    assert called_with_file
+
+
+def clean_env() -> None:
+    if "S3GW_LOG_FILE" in os.environ:
+        del os.environ["S3GW_LOG_FILE"]
+    if "S3GW_DEBUG" in os.environ:
+        del os.environ["S3GW_DEBUG"]
+
+
+def test_set_logging_config(mocker: MockerFixture) -> None:
+    called_set_default_cfg = False
+    called_set_debug_cfg = False
+    called_set_file_cfg = False
+
+    def mock_set_default_config(cfg: Dict[str, Any]) -> None:
+        nonlocal called_set_default_cfg
+        called_set_default_cfg = True
+        assert "handlers" in cfg
+        assert "log_file" not in cfg["handlers"]
+        assert "root" in cfg
+        assert "handlers" in cfg["root"]
+        assert "log_file" not in cfg["root"]["handlers"]
+        assert cfg["handlers"]["console"]["level"] == "INFO"
+
+    def mock_set_debug_config(cfg: Dict[str, Any]) -> None:
+        nonlocal called_set_debug_cfg
+        called_set_debug_cfg = True
+        assert cfg["handlers"]["console"]["level"] == "DEBUG"
+
+    def mock_set_file_config(cfg: Dict[str, Any]) -> None:
+        nonlocal called_set_file_cfg
+        called_set_file_cfg = True
+        assert "log_file" in cfg["handlers"]
+        assert cfg["handlers"]["log_file"]["filename"] == "foo"
+        assert "log_file" in cfg["root"]["handlers"]
+
+    mocker.patch("logging.config.dictConfig", new=mock_set_default_config)
+    clean_env()
+    backend.logging.setup_logging()
+    assert called_set_default_cfg
+
+    mocker.patch("logging.config.dictConfig", new=mock_set_debug_config)
+    clean_env()
+    os.environ["S3GW_DEBUG"] = "1"
+    backend.logging.setup_logging()
+    assert called_set_debug_cfg
+
+    mocker.patch("logging.config.dictConfig", new=mock_set_file_config)
+    clean_env()
+    os.environ["S3GW_LOG_FILE"] = "foo"
+    backend.logging.setup_logging()
+    assert called_set_file_cfg

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -25,6 +25,9 @@ extend_skip_glob = ["frontend/*"]
 [tool.pyright]
 
 [tool.pytest.ini_options]
+pythonpath = [
+  "."
+]
 addopts = [
     "--cov",
     "--cov-append",

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -23,6 +23,7 @@ line_length = 80
 extend_skip_glob = ["frontend/*"]
 
 [tool.pyright]
+typeCheckingMode = "strict"
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -23,3 +23,12 @@ line_length = 80
 extend_skip_glob = ["frontend/*"]
 
 [tool.pyright]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--cov",
+    "--cov-append",
+    "--cov-report=term",
+    "--cov-report=xml",
+    "--cov-report=html"
+]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.black]
+line-length = 80
+target-version = ['py310']
+extend-exclude = '''
+# A regex preceded with ^/ will apply only to files and directories
+# in the root of the project.
+# As this is 'extend', we already exclude everything in .gitignore.
+^/(
+  (
+    frontend
+  )/
+)
+'''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 80
+extend_skip_glob = ["frontend/*"]
+
+[tool.pyright]

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,0 +1,8 @@
+black
+isort
+tox
+pytest
+pytest-asyncio
+pytest-cov
+pytest-mock
+pyright

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-asyncio
 pytest-cov
 pytest-mock
 pyright
+moto[server,s3]

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -2,7 +2,6 @@ black
 isort
 tox
 pytest
-pytest-asyncio
 pytest-cov
 pytest-mock
 pyright

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.95.0
+pydantic==1.10.7
+uvicorn==0.21.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,9 @@
 fastapi==0.95.0
 pydantic==1.10.7
 uvicorn==0.21.1
+aioboto3==11.0.1
+types-aiobotocore==2.5.0.post2
+types-aiobotocore-s3==2.5.0.post1
+# for some reason we need the lite version as well to have type annotations
+# on session.create_client(), despite what the documentation says.
+types-aiobotocore-lite==2.5.0.post2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,11 +3,9 @@ pydantic==1.10.7
 uvicorn==0.21.1
 aioboto3==11.0.1
 
+types-aioboto3
 types-aiobotocore==2.5.0.post2
 types-aiobotocore-s3==2.5.0.post1
-# for some reason we need the lite version as well to have type annotations
-# on session.create_client(), despite what the documentation says.
-types-aiobotocore-lite==2.5.0.post2
 
 # already a dependency of fastapi, but we are now explicitly using it.
 anyio==3.6.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,8 +2,12 @@ fastapi==0.95.0
 pydantic==1.10.7
 uvicorn==0.21.1
 aioboto3==11.0.1
+
 types-aiobotocore==2.5.0.post2
 types-aiobotocore-s3==2.5.0.post1
 # for some reason we need the lite version as well to have type annotations
 # on session.create_client(), despite what the documentation says.
 types-aiobotocore-lite==2.5.0.post2
+
+# already a dependency of fastapi, but we are now explicitly using it.
+anyio==3.6.2

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -22,6 +22,7 @@ from fastapi import FastAPI
 from fastapi.logger import logger
 from fastapi.staticfiles import StaticFiles
 
+from backend.api import bucket
 from backend.logging import setup_logging
 
 
@@ -65,7 +66,7 @@ def s3gw_factory(
     async def on_shutdown():  # type: ignore
         await shutdown(s3gw_app, s3gw_api)
 
-    # s3gw_api.include_router()
+    s3gw_api.include_router(bucket.router)
 
     s3gw_app.mount("/api", s3gw_api, name="api")
     if static_dir is not None:

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Awaitable, Callable
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.logger import logger
+from fastapi.staticfiles import StaticFiles
+
+from backend.logging import setup_logging
+
+
+async def s3gw_startup(s3gw_app: FastAPI, s3gw_api: FastAPI) -> None:
+    setup_logging()
+    logger.info("Starting s3gw-ui backend")
+
+
+async def s3gw_shutdown(s3gw_app: FastAPI, s3gw_api: FastAPI) -> None:
+    logger.info("Shutting down s3gw-ui backend")
+
+
+s3gwAsyncMethod = Callable[[FastAPI, FastAPI], Awaitable[None]]
+
+
+def s3gw_factory(
+    startup: s3gwAsyncMethod = s3gw_startup,
+    shutdown: s3gwAsyncMethod = s3gw_shutdown,
+    static_dir: str | None = None,
+) -> FastAPI:
+    api_tags_meta = [
+        {
+            "name": "bucket",
+            "description": "Bucket related operations",
+        },
+    ]
+
+    s3gw_app = FastAPI(docs_url=None)
+    s3gw_api = FastAPI(
+        title="s3gw-ui API",
+        description="<s3gw description>",
+        version="1.0.0",
+        openapi_tags=api_tags_meta,
+    )
+
+    @s3gw_app.on_event("startup")
+    async def on_startup():  # type: ignore
+        await startup(s3gw_app, s3gw_api)
+
+    @s3gw_app.on_event("shutdown")
+    async def on_shutdown():  # type: ignore
+        await shutdown(s3gw_app, s3gw_api)
+
+    # s3gw_api.include_router()
+
+    s3gw_app.mount("/api", s3gw_api, name="api")
+    if static_dir is not None:
+        s3gw_app.mount(
+            "/", StaticFiles(directory=static_dir, html=True), name="static"
+        )
+
+    return s3gw_app
+
+
+def app_factory():
+    static_dir = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "frontend/dist/s3gw-ui/"
+    )
+    return s3gw_factory(s3gw_startup, s3gw_shutdown, static_dir)
+
+
+def main():
+    # use this for development; production systems should be running with
+    # uvicorn directly.
+    uvicorn.run(  # type: ignore
+        "s3gw_ui_backend:app_factory", host="0.0.0.0", port=8080, factory=True
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -14,14 +14,6 @@ deps =
 deps =
   -rrequirements-dev.txt
 
-[pytest]
-addopts =
-  --cov
-  --cov-append
-  --cov-report=term
-  --cov-report=xml
-  --cov-report=html
-
 [testenv]
 description = run the tests with pytest
 deps =

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,0 +1,82 @@
+[tox]
+env_list =
+    py310,
+    types,
+    lint
+minversion = 4.4.8
+skipsdist = true
+
+[base]
+deps =
+  -rrequirements.txt
+
+[base-dev]
+deps =
+  -rrequirements-dev.txt
+
+[pytest]
+addopts =
+  --cov
+  --cov-append
+  --cov-report=term
+  --cov-report=xml
+
+[testenv]
+description = run the tests with pytest
+deps =
+    pytest>=6
+    {[base]deps}
+    {[base-dev]deps}
+commands =
+    pytest {posargs: \
+      s3gw_ui_backend.py backend/ }
+
+[testenv:types]
+description = check type correctness
+deps =
+    pytest>=6
+    {[base]deps}
+    {[base-dev]deps}
+commands =
+    pyright \
+      --pythonversion 3.10 \
+      --pythonplatform Linux \
+      s3gw_ui_backend.py backend/
+
+[testenv:lint]
+description = check code formatting
+skip_install = true
+deps =
+    black
+    isort
+modules =
+    s3gw_ui_backend.py \
+    backend
+commands =
+    black --check \
+      --diff \
+      {posargs:{[testenv:lint]modules}}
+    isort --check-only \
+      --diff \
+      {posargs:{[testenv:lint]modules}}
+
+[testenv:lint-fix]
+description = fix code formatting
+skip_install = true
+deps =
+    black
+    isort
+modules =
+    s3gw_ui_backend.py \
+    backend
+commands =
+    black \
+      {posargs:{[testenv:lint]modules}}
+    isort \
+      {posargs:{[testenv:lint]modules}}
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -24,6 +24,13 @@ commands =
     pytest {posargs: \
       s3gw_ui_backend.py backend/ }
 
+[testenv:py310-with-s3gw]
+setenv =
+    S3GW_TEST_ENDPOINT=http://127.0.0.1:7480
+    S3GW_TEST_ACCESS_KEY=test
+    S3GW_TEST_SECRET_KEY=test
+    S3GW_TEST_DEBUG=1
+
 [testenv:types]
 description = check type correctness
 deps =
@@ -72,4 +79,3 @@ commands =
 deps = coverage
 skip_install = true
 commands = coverage erase
-

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -20,6 +20,7 @@ addopts =
   --cov-append
   --cov-report=term
   --cov-report=xml
+  --cov-report=html
 
 [testenv]
 description = run the tests with pytest

--- a/src/typings/aiobotocore/session.pyi
+++ b/src/typings/aiobotocore/session.pyi
@@ -1,0 +1,67 @@
+from types import TracebackType
+from typing import Any, List, Optional, Type, Union
+
+from aiobotocore.client import AioBaseClient as AioBaseClient
+from aiobotocore.client import AioClientCreator as AioClientCreator
+from aiobotocore.credentials import AioCredentials as AioCredentials
+from aiobotocore.credentials import create_credential_resolver as create_credential_resolver
+from aiobotocore.hooks import AioHierarchicalEmitter as AioHierarchicalEmitter
+from aiobotocore.parsers import AioResponseParserFactory as AioResponseParserFactory
+from botocore.config import Config
+from botocore.model import ServiceModel
+from botocore.session import EVENT_ALIASES as EVENT_ALIASES
+from botocore.session import Session
+
+class ClientCreatorContext:
+    def __init__(self, coro: Any) -> None: ...
+    async def __aenter__(self) -> AioBaseClient: ...
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None: ...
+
+class AioSession(Session):
+    def __init__(
+        self,
+        session_vars: Optional[Any] = ...,
+        event_hooks: Optional[Any] = ...,
+        include_builtin_handlers: bool = ...,
+        profile: Optional[Any] = ...,
+    ) -> None: ...
+    def register(
+        self,
+        event_name: str,
+        handler: Any,
+        unique_id: Optional[Any] = ...,
+        unique_id_uses_count: bool = ...,
+    ) -> None: ...
+    def create_client(  # type: ignore [override]
+        self,
+        service_name: str,
+        region_name: Optional[str] = ...,
+        api_version: Optional[str] = ...,
+        use_ssl: Optional[bool] = ...,
+        verify: Union[bool, str, None] = ...,
+        endpoint_url: Optional[str] = ...,
+        aws_access_key_id: Optional[str] = ...,
+        aws_secret_access_key: Optional[str] = ...,
+        aws_session_token: Optional[str] = ...,
+        config: Optional[Config] = ...,
+    ) -> AioBaseClient: ...
+    async def get_credentials(self) -> AioCredentials: ...  # type: ignore [override]
+    def set_credentials(
+        self, access_key: str, secret_key: str, token: Optional[Any] = ...
+    ) -> None: ...
+    async def get_service_model(  # type: ignore [override]
+        self, service_name: str, api_version: Optional[Any] = ...
+    ) -> ServiceModel: ...
+    async def get_service_data(
+        self, service_name: str, api_version: Optional[Any] = ...
+    ) -> Any: ...
+    async def get_available_regions(  # type: ignore [override]
+        self, service_name: str, partition_name: str = ..., allow_non_regional: bool = ...
+    ) -> List[str]: ...
+
+def get_session(env_vars: Optional[Any] = ...) -> AioSession: ...


### PR DESCRIPTION
This patchset introduces a backend daemon for the current s3gw-ui frontend.

This is done in two major steps:

1. creating a `src/` hierarchy, where the frontend files live (i.e., `src/frontend/`);
2. adding a `src/backend/` and a `src/s3gw_ui_backend.py` script for all things backend-related.

We are not currently building a container with the backend, nor are we changing frontend sources to use the backend.

The backend code is still mostly a skeleton, with few operations implemented, mostly for demonstration purposes. Regardless, the whole infrastructure for backend testing, linting, and static type checking has been set up.

In `src/backend/README.md` we can find instructions for developers.

This should be considered a draft for the time being, as we sort out how we should proceed with integrating with the frontend.