### PR TITLE
Increase z-index of the notification sidebar

### DIFF
--- a/src/frontend/src/app/shared/layouts/main-layout/main-layout.component.scss
+++ b/src/frontend/src/app/shared/layouts/main-layout/main-layout.component.scss
@@ -42,7 +42,7 @@ $notifications-width: 350px;
       right: -$notifications-width;
       top: calc(#{dv.$s3gw-site-header-height} - 1px);
       transition: right 0.3s;
-      z-index: 1000;
+      z-index: 1030; // Must be > than Bootstraps `.sticky-top`
 
       &.visible {
         right: 0;


### PR DESCRIPTION
![Bildschirmfoto vom 2023-04-13 12-49-52](https://user-images.githubusercontent.com/1897962/231740250-4fa3bf57-3ea5-4d9d-b49e-54c30f50a61d.png)

The z-index was smaller than Bootstraps `sticky-top`, so the datatable header row overlapped the notification sidebar.

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
