### PR TITLE
UI: Validate access key

### DIFF
--- a/src/frontend/src/app/pages/admin/user/user-key-form-page/user-key-form-page.component.ts
+++ b/src/frontend/src/app/pages/admin/user/user-key-form-page/user-key-form-page.component.ts
@@ -98,7 +98,11 @@ export class UserKeyFormPageComponent implements OnInit, IsDirty {
             requiredIf: {
               operator: 'falsy',
               arg0: { prop: 'generate_key' }
-            }
+            },
+            // https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
+            pattern: /^[\w]+$/,
+            minLength: 16,
+            maxLength: 128
           },
           modifiers: [
             {


### PR DESCRIPTION
The regex `/^[\w]{16,128}$/` is not used by intention. Instead the `minLength` and `maxLength` validators are used to display more human readable error messages.

References:
- https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
