### PR TITLE
UI: Replace ng-block-ui library to be able to upgrade Angular

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -29,7 +29,6 @@
         "dayjs": "^1.11.7",
         "file-saver": "^2.0.5",
         "lodash": "^4.17.21",
-        "ng-block-ui": "^3.0.2",
         "ngx-toastr": "^14.3.0",
         "rxjs": "~7.5.7",
         "tslib": "^2.5.0",
@@ -16454,19 +16453,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node_modules/ng-block-ui": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ng-block-ui/-/ng-block-ui-3.0.2.tgz",
-      "integrity": "sha512-EP3IXP8WSoKQOAwunf/v77aydcBCSLkEm5K8duRMSXFsnrcTdNqUiaLDKCf9U3COHY52IVBJcLb9PGhMBCWVSA==",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/ng-block-ui/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/ngx-toastr": {
       "version": "14.3.0",
@@ -35242,21 +35228,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "ng-block-ui": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ng-block-ui/-/ng-block-ui-3.0.2.tgz",
-      "integrity": "sha512-EP3IXP8WSoKQOAwunf/v77aydcBCSLkEm5K8duRMSXFsnrcTdNqUiaLDKCf9U3COHY52IVBJcLb9PGhMBCWVSA==",
-      "requires": {
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
     },
     "ngx-toastr": {
       "version": "14.3.0",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -42,7 +42,6 @@
     "dayjs": "^1.11.7",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.21",
-    "ng-block-ui": "^3.0.2",
     "ngx-toastr": "^14.3.0",
     "rxjs": "~7.5.7",
     "tslib": "^2.5.0",

--- a/src/frontend/src/app/app.component.html
+++ b/src/frontend/src/app/app.component.html
@@ -1,3 +1,4 @@
+<s3gw-block-ui></s3gw-block-ui>
 <s3gw-alert-panel *ngIf="!isRgwServiceConfigValid"
                   type="danger"
                   noMargin

--- a/src/frontend/src/app/pages/admin/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/admin/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { EMPTY, Observable, throwError } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
 
@@ -29,9 +28,6 @@ import { RxjsUiHelperService } from '~/app/shared/services/rxjs-ui-helper.servic
   styleUrls: ['./bucket-datatable-page.component.scss']
 })
 export class BucketDatatablePageComponent {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   public buckets: Bucket[] = [];
   public datatableActions: DatatableAction[];
   public datatableColumns: DatatableColumn[];

--- a/src/frontend/src/app/pages/admin/user/user-datatable-page/user-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/admin/user/user-datatable-page/user-datatable-page.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
@@ -29,9 +28,6 @@ import { RxjsUiHelperService } from '~/app/shared/services/rxjs-ui-helper.servic
   styleUrls: ['./user-datatable-page.component.scss']
 })
 export class UserDatatablePageComponent {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   public datatableActions: DatatableAction[];
   public datatableColumns: DatatableColumn[];
   public icons = Icon;

--- a/src/frontend/src/app/pages/admin/user/user-key-datatable-page/user-key-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/admin/user/user-key-datatable-page/user-key-datatable-page.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
@@ -30,9 +29,6 @@ import { RxjsUiHelperService } from '~/app/shared/services/rxjs-ui-helper.servic
   styleUrls: ['./user-key-datatable-page.component.scss']
 })
 export class UserKeyDatatablePageComponent implements OnInit {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   public datatableActions: DatatableAction[];
   public datatableColumns: DatatableColumn[];
   public icons = Icon;

--- a/src/frontend/src/app/pages/shared/bucket/bucket-lifecycle-datatable-page/bucket-lifecycle-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/shared/bucket/bucket-lifecycle-datatable-page/bucket-lifecycle-datatable-page.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Params } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as AWS from 'aws-sdk';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { finalize } from 'rxjs/operators';
 
 import { format } from '~/app/functions.helper';
@@ -26,15 +25,13 @@ import { S3BucketService } from '~/app/shared/services/api/s3-bucket.service';
 import { DialogService } from '~/app/shared/services/dialog.service';
 import { ModalDialogService } from '~/app/shared/services/modal-dialog.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
+
 @Component({
   selector: 's3gw-bucket-lifecycle-datatable-page',
   templateUrl: './bucket-lifecycle-datatable-page.component.html',
   styleUrls: ['./bucket-lifecycle-datatable-page.component.scss']
 })
 export class BucketLifecycleDatatablePageComponent implements OnInit {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   public bid: AWS.S3.Types.BucketName = '';
   public rules: AWS.S3.Types.LifecycleRules = [];
   public datatableActions: DatatableAction[];

--- a/src/frontend/src/app/pages/shared/login-page/login-page.component.ts
+++ b/src/frontend/src/app/pages/shared/login-page/login-page.component.ts
@@ -2,13 +2,13 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { finalize } from 'rxjs/operators';
 
 import { translate } from '~/app/i18n.helper';
 import { DeclarativeFormComponent } from '~/app/shared/components/declarative-form/declarative-form.component';
 import { DeclarativeFormConfig } from '~/app/shared/models/declarative-form-config.type';
 import { AuthResponse, AuthService } from '~/app/shared/services/api/auth.service';
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
 import { DialogService } from '~/app/shared/services/dialog.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 
@@ -18,9 +18,6 @@ import { NotificationService } from '~/app/shared/services/notification.service'
   styleUrls: ['./login-page.component.scss']
 })
 export class LoginPageComponent implements OnInit {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   @ViewChild(DeclarativeFormComponent, { static: true })
   form!: DeclarativeFormComponent;
 
@@ -58,24 +55,29 @@ export class LoginPageComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
+    private blockUiService: BlockUiService,
     private dialogService: DialogService,
     private notificationService: NotificationService,
     private router: Router
   ) {}
 
   ngOnInit(): void {
-    this.blockUI.resetGlobal();
+    this.blockUiService.resetGlobal();
     // Ensure all open modal dialogs are closed.
     this.dialogService.dismissAll();
   }
 
   onLogin(): void {
     this.errorMessage = undefined;
-    this.blockUI.start(translate(TEXT('Please wait ...')));
+    this.blockUiService.start(translate(TEXT('Please wait ...')));
     const values = this.form.values;
     this.authService
       .login(values['accessKey'], values['secretKey'])
-      .pipe(finalize(() => this.blockUI.stop()))
+      .pipe(
+        finalize(() => {
+          this.blockUiService.stop();
+        })
+      )
       .subscribe({
         next: (resp: AuthResponse) => {
           this.router.navigate(['/dashboard']);

--- a/src/frontend/src/app/pages/user/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/user/bucket/bucket-datatable-page/bucket-datatable-page.component.ts
@@ -3,7 +3,6 @@ import { Router } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as AWS from 'aws-sdk';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { Observable, throwError } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
 
@@ -30,9 +29,6 @@ import { RxjsUiHelperService } from '~/app/shared/services/rxjs-ui-helper.servic
   styleUrls: ['./bucket-datatable-page.component.scss']
 })
 export class BucketDatatablePageComponent {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   public buckets: AWS.S3.Types.Buckets = [];
   public datatableActions: DatatableAction[];
   public datatableColumns: DatatableColumn[];

--- a/src/frontend/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
@@ -5,7 +5,6 @@ import { ActivatedRoute, Params, Router } from '@angular/router';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
 import * as AWS from 'aws-sdk';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { forkJoin, merge, Observable, of, Subscription, timer } from 'rxjs';
 import { finalize, map, switchMap } from 'rxjs/operators';
 
@@ -40,6 +39,7 @@ import {
   S3ObjectVersionList,
   S3UploadProgress
 } from '~/app/shared/services/api/s3-bucket.service';
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
 import { DialogService } from '~/app/shared/services/dialog.service';
 import { ModalDialogService } from '~/app/shared/services/modal-dialog.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -51,9 +51,6 @@ import { RxjsUiHelperService } from '~/app/shared/services/rxjs-ui-helper.servic
   styleUrls: ['./object-datatable-page.component.scss']
 })
 export class ObjectDatatablePageComponent implements OnInit {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   @ViewChild('nameColumnTpl', { static: true })
   nameColumnTpl?: TemplateRef<any>;
 
@@ -77,6 +74,7 @@ export class ObjectDatatablePageComponent implements OnInit {
   private showDeletedObjects = false;
 
   constructor(
+    private blockUiService: BlockUiService,
     private clipboard: Clipboard,
     private dialogService: DialogService,
     private localeDatePipe: LocaleDatePipe,
@@ -538,7 +536,7 @@ export class ObjectDatatablePageComponent implements OnInit {
     if (!fileList) {
       return;
     }
-    this.blockUI.start(
+    this.blockUiService.start(
       format(translate(TEXT('Please wait, uploading {{ total }} object(s) ...')), {
         total: fileList.length
       })
@@ -546,10 +544,10 @@ export class ObjectDatatablePageComponent implements OnInit {
     this.subscriptions.add(
       this.s3BucketService
         .uploadObjects(this.bid, fileList, this.s3BucketService.buildPrefix(this.prefixParts))
-        .pipe(finalize(() => this.blockUI.stop()))
+        .pipe(finalize(() => this.blockUiService.stop()))
         .subscribe({
           next: (progress: S3UploadProgress) => {
-            this.blockUI.update(
+            this.blockUiService.update(
               format(
                 translate(
                   TEXT(

--- a/src/frontend/src/app/shared/components/block-ui/block-ui.component.html
+++ b/src/frontend/src/app/shared/components/block-ui/block-ui.component.html
@@ -1,0 +1,8 @@
+<div *ngIf="blockUiService.visible$ | async"
+     class="w-100 h-100 wrapper"
+     @fadeInOut>
+  <div class="container">
+    <div class="spinner"></div>
+    <div class="fs-5 text-center text-white mt-1">{{ blockUiService.message$ | async | transloco | sanitize }}</div>
+  </div>
+</div>

--- a/src/frontend/src/app/shared/components/block-ui/block-ui.component.scss
+++ b/src/frontend/src/app/shared/components/block-ui/block-ui.component.scss
@@ -1,0 +1,39 @@
+@use 'src/scss/defaults/colors' as dc;
+
+.wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  background: dc.$s3gw-color-transparent-black;
+  z-index: 30000; // Must be > than Bootstraps $zindex-sticky
+  cursor: wait;
+
+  .container {
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    .spinner {
+      animation: spinner-animation 1s infinite linear;
+      box-sizing: border-box;
+      border: 5px solid dc.$s3gw-color-cerulean-900;
+      border-radius: 50%;
+      border-top-color: dc.$s3gw-color-cerulean-500;
+      height: 80px;
+      width: 80px;
+      margin: 0 auto;
+    }
+  }
+}
+
+@keyframes spinner-animation {
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(359deg);
+  }
+}

--- a/src/frontend/src/app/shared/components/block-ui/block-ui.component.spec.ts
+++ b/src/frontend/src/app/shared/components/block-ui/block-ui.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BlockUiComponent } from '~/app/shared/components/block-ui/block-ui.component';
+
+describe('BlockUiComponent', () => {
+  let component: BlockUiComponent;
+  let fixture: ComponentFixture<BlockUiComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BlockUiComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BlockUiComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/shared/components/block-ui/block-ui.component.ts
+++ b/src/frontend/src/app/shared/components/block-ui/block-ui.component.ts
@@ -1,0 +1,20 @@
+import { animate, style, transition, trigger } from '@angular/animations';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
+
+@Component({
+  selector: 's3gw-block-ui',
+  templateUrl: './block-ui.component.html',
+  styleUrls: ['./block-ui.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [
+    trigger('fadeInOut', [
+      transition(':enter', [style({ opacity: 0 }), animate('250ms', style({ opacity: 1 }))]),
+      transition(':leave', [animate('250ms', style({ opacity: 0 }))])
+    ])
+  ]
+})
+export class BlockUiComponent {
+  constructor(public blockUiService: BlockUiService) {}
+}

--- a/src/frontend/src/app/shared/components/components.module.ts
+++ b/src/frontend/src/app/shared/components/components.module.ts
@@ -4,9 +4,9 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslocoModule } from '@ngneat/transloco';
-import { BlockUIModule } from 'ng-block-ui';
 
 import { AlertPanelComponent } from '~/app/shared/components/alert-panel/alert-panel.component';
+import { BlockUiComponent } from '~/app/shared/components/block-ui/block-ui.component';
 import { BreadcrumbsComponent } from '~/app/shared/components/breadcrumbs/breadcrumbs.component';
 import { DashboardWidgetComponent } from '~/app/shared/components/dashboard-widget/dashboard-widget.component';
 import { DatatableComponent } from '~/app/shared/components/datatable/datatable.component';
@@ -48,7 +48,8 @@ import { PipesModule } from '~/app/shared/pipes/pipes.module';
     DatatableSecondaryHeaderComponent,
     PageActionsComponent,
     TagsInputComponent,
-    NotificationBarComponent
+    NotificationBarComponent,
+    BlockUiComponent
   ],
   exports: [
     AlertPanelComponent,
@@ -68,10 +69,10 @@ import { PipesModule } from '~/app/shared/pipes/pipes.module';
     DatatableSecondaryHeaderComponent,
     PageActionsComponent,
     TagsInputComponent,
-    NotificationBarComponent
+    NotificationBarComponent,
+    BlockUiComponent
   ],
   imports: [
-    BlockUIModule,
     CommonModule,
     DirectivesModule,
     FormsModule,

--- a/src/frontend/src/app/shared/components/page-wrapper/page-wrapper.component.ts
+++ b/src/frontend/src/app/shared/components/page-wrapper/page-wrapper.component.ts
@@ -1,9 +1,9 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { marker as TEXT } from '@ngneat/transloco-keys-manager/marker';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 
 import { translate } from '~/app/i18n.helper';
 import { PageAction } from '~/app/shared/models/page-action.type';
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
 
 export enum PageStatus {
   none = 0,
@@ -21,9 +21,6 @@ export enum PageStatus {
   styleUrls: ['./page-wrapper.component.scss']
 })
 export class PageWrapperComponent implements OnChanges, OnDestroy {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
   @Input()
   pageStatus: PageStatus = PageStatus.ready;
 
@@ -39,18 +36,20 @@ export class PageWrapperComponent implements OnChanges, OnDestroy {
   @Input()
   actions?: PageAction[] = [];
 
+  constructor(private blockUiService: BlockUiService) {}
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['pageStatus'].currentValue === PageStatus.saving) {
-      this.blockUI.start(translate(this.savingText!));
+      this.blockUiService.start(translate(this.savingText!));
     }
     if (changes['pageStatus'].previousValue === PageStatus.saving) {
-      this.blockUI.stop();
+      this.blockUiService.stop();
     }
   }
 
   ngOnDestroy(): void {
     if (this.pageStatus === PageStatus.saving) {
-      this.blockUI.stop();
+      this.blockUiService.stop();
     }
   }
 }

--- a/src/frontend/src/app/shared/layouts/blank-layout/blank-layout.component.html
+++ b/src/frontend/src/app/shared/layouts/blank-layout/blank-layout.component.html
@@ -1,3 +1,1 @@
-<block-ui>
-  <router-outlet></router-outlet>
-</block-ui>
+<router-outlet></router-outlet>

--- a/src/frontend/src/app/shared/layouts/main-layout/main-layout.component.html
+++ b/src/frontend/src/app/shared/layouts/main-layout/main-layout.component.html
@@ -1,24 +1,22 @@
-<block-ui>
-  <div class="main-layout"
-       [ngClass]="{'collapsed': navigationCollapsed}">
-    <header>
-      <s3gw-top-bar class="w-100"
-                    (toggleNavigation)="navigationCollapsed = !navigationCollapsed"
-                    (toggleNotifications)="notificationsCollapsed = !notificationsCollapsed">
-      </s3gw-top-bar>
-    </header>
-    <aside class="navigation">
-      <s3gw-navigation-bar class="w-100"
-                           [items]="navigationItems">
-      </s3gw-navigation-bar>
-    </aside>
-    <main>
-      <router-outlet></router-outlet>
-    </main>
-    <aside class="shadow notifications"
-           [ngClass]="{'visible': !notificationsCollapsed}">
-      <s3gw-notification-bar></s3gw-notification-bar>
-    </aside>
-    <footer></footer>
-  </div>
-</block-ui>
+<div class="main-layout"
+     [ngClass]="{'collapsed': navigationCollapsed}">
+  <header>
+    <s3gw-top-bar class="w-100"
+                  (toggleNavigation)="navigationCollapsed = !navigationCollapsed"
+                  (toggleNotifications)="notificationsCollapsed = !notificationsCollapsed">
+    </s3gw-top-bar>
+  </header>
+  <aside class="navigation">
+    <s3gw-navigation-bar class="w-100"
+                         [items]="navigationItems">
+    </s3gw-navigation-bar>
+  </aside>
+  <main>
+    <router-outlet></router-outlet>
+  </main>
+  <aside class="shadow notifications"
+         [ngClass]="{'visible': !notificationsCollapsed}">
+    <s3gw-notification-bar></s3gw-notification-bar>
+  </aside>
+  <footer></footer>
+</div>

--- a/src/frontend/src/app/shared/services/block-ui.service.spec.ts
+++ b/src/frontend/src/app/shared/services/block-ui.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
+
+describe('BlockUiService', () => {
+  let service: BlockUiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BlockUiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/shared/services/block-ui.service.ts
+++ b/src/frontend/src/app/shared/services/block-ui.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+type Message = string | undefined;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BlockUiService {
+  public readonly visible$: Observable<boolean>;
+  public readonly message$: Observable<Message>;
+
+  private visible: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  private message: BehaviorSubject<Message> = new BehaviorSubject<Message>(undefined);
+
+  constructor() {
+    this.visible$ = this.visible.asObservable();
+    this.message$ = this.message.asObservable();
+  }
+
+  start(message: Message): void {
+    this.visible.next(true);
+    this.message.next(message);
+  }
+
+  stop(): void {
+    this.visible.next(false);
+  }
+
+  update(message: Message): void {
+    this.message.next(message);
+  }
+
+  resetGlobal(): void {
+    this.visible.next(false);
+    this.message.next(undefined);
+  }
+}

--- a/src/frontend/src/app/shared/services/rxjs-ui-helper.service.ts
+++ b/src/frontend/src/app/shared/services/rxjs-ui-helper.service.ts
@@ -1,20 +1,20 @@
 import { Injectable } from '@angular/core';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { concat, forkJoin, Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
 import { format } from '~/app/functions.helper';
 import { translate } from '~/app/i18n.helper';
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RxjsUiHelperService {
-  @BlockUI()
-  blockUI!: NgBlockUI;
-
-  constructor(private notificationService: NotificationService) {}
+  constructor(
+    private blockUiService: BlockUiService,
+    private notificationService: NotificationService
+  ) {}
 
   /**
    * Sequentially process the given observables.
@@ -53,17 +53,17 @@ export class RxjsUiHelperService {
     return new Observable<T>((observer: any) => {
       let current = 0;
       const total = sources.length;
-      this.blockUI.start(format(translate(messages.start), { total }));
+      this.blockUiService.start(format(translate(messages.start), { total }));
       concat(...sources)
         .pipe(
           finalize(() => {
-            this.blockUI.stop();
+            this.blockUiService.stop();
           })
         )
         .subscribe({
           next: (value: T) => {
             current += 1;
-            this.blockUI.update(
+            this.blockUiService.update(
               format(translate(messages.next), {
                 current,
                 total,
@@ -100,11 +100,11 @@ export class RxjsUiHelperService {
     successNotification: string
   ): Observable<any> {
     return new Observable((observer: any) => {
-      this.blockUI.start(translate(message));
+      this.blockUiService.start(translate(message));
       forkJoin(sources)
         .pipe(
           finalize(() => {
-            this.blockUI.stop();
+            this.blockUiService.stop();
           })
         )
         .subscribe({

--- a/src/frontend/src/app/shared/shared.module.ts
+++ b/src/frontend/src/app/shared/shared.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
-import { BlockUIModule } from 'ng-block-ui';
 
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { DirectivesModule } from '~/app/shared/directives/directives.module';
@@ -13,7 +12,6 @@ import { PipesModule } from '~/app/shared/pipes/pipes.module';
 @NgModule({
   declarations: [BlankLayoutComponent, MainLayoutComponent],
   imports: [
-    BlockUIModule.forRoot(),
     CommonModule,
     ComponentsModule,
     DirectivesModule,

--- a/src/frontend/src/index.html
+++ b/src/frontend/src/index.html
@@ -22,7 +22,6 @@
       animation: spinner-animation 1s infinite linear;
       box-sizing: border-box;
       border: 5px solid #008acf;
-      border-top-color: rgb(0, 138, 207);
       border-radius: 50%;
       border-top-color: #00b2e2;
       height: 80px;

--- a/src/frontend/src/scss/blockui.scss
+++ b/src/frontend/src/scss/blockui.scss
@@ -1,7 +1,0 @@
-.block-ui-wrapper {
-  background: rgba(0, 0, 0, 0.54) !important;
-
-  .block-ui-spinner {
-    top: 50%;
-  }
-}

--- a/src/frontend/src/styles.scss
+++ b/src/frontend/src/styles.scss
@@ -1,5 +1,4 @@
 @import 'src/scss/defaults';
-@import 'src/scss/blockui';
 @import 'src/scss/bootstrap';
 @import 'src/scss/ngx-toastr';
 


### PR DESCRIPTION
Note:
- The method names of ng-block-ui has been kept
- The new component does not have all the features of ng-block-ui. But that does not matter because they were not all used anyway.

Fixes: https://github.com/aquarist-labs/s3gw/issues/508

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
