### PR TITLE
UI: The datatable pagination does not show the correct number of displayed items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not display objects that have also a delete marker (gh#aquarist-labs/s3gw#548).
 - Search button only performs a search on a page level (gh#aquarist-labs/s3gw#556).
+- The datatable pagination does not show the correct number of displayed items (gh#aquarist-labs/s3gw#559).
 
 ## [0.16.0]
 

--- a/src/frontend/src/app/shared/components/datatable/datatable.component.html
+++ b/src/frontend/src/app/shared/components/datatable/datatable.component.html
@@ -87,7 +87,7 @@
       </tr>
     </thead>
     <tbody>
-      <ng-container *ngFor="let row of filteredData">
+      <ng-container *ngFor="let row of displayedData">
         <tr class="align-middle"
             [ngClass]="{'selected': selected.includes(row), 's3gw-cursor-pointer': selectionType !== 'none'}">
           <td *ngFor="let column of columns"
@@ -159,9 +159,9 @@
       </div>
     </div>
     <div class="mx-4 mb-3 mt-0 text-nowrap">
-      {{ (page - 1) * pageSize + 1 }} - {{ page * pageSize > data.length ? data.length : page * pageSize }} {{ 'of' | transloco }} {{ data.length }}
+      {{ (page - 1) * pageSize + 1 }} - {{ page * pageSize > filteredData.length ? filteredData.length : page * pageSize }} {{ 'of' | transloco }} {{ filteredData.length }}
     </div>
-    <ngb-pagination [collectionSize]="data.length"
+    <ngb-pagination [collectionSize]="filteredData.length"
                     [page]="page"
                     [pageSize]="pageSize"
                     (pageChange)="onPageChange($event)">

--- a/src/frontend/src/app/shared/components/datatable/datatable.component.spec.ts
+++ b/src/frontend/src/app/shared/components/datatable/datatable.component.spec.ts
@@ -72,7 +72,7 @@ describe('DatatableComponent', () => {
     fixture.detectChanges();
     expect(component.sortHeader).toBe('foo');
     expect(component.sortDirection).toBe(SortDirection.ascending);
-    expect(component.filteredData).toEqual([data.a, data.b, data.c]);
+    expect(component.displayedData).toEqual([data.a, data.b, data.c]);
   });
 
   it('should sort after specific column', () => {
@@ -81,24 +81,24 @@ describe('DatatableComponent', () => {
     fixture.detectChanges();
     expect(component.sortHeader).toBe('bar');
     expect(component.sortDirection).toBe(SortDirection.descending);
-    expect(component.filteredData).toEqual([data.b, data.a, data.c]);
+    expect(component.displayedData).toEqual([data.b, data.a, data.c]);
   });
 
   it('should reverse listing order if the current sorting header is clicked', () => {
     fixture.detectChanges();
     component.onSortChange(columns[0]);
     expect(component.sortDirection).toBe(SortDirection.descending);
-    expect(component.filteredData).toEqual([data.c, data.b, data.a]);
+    expect(component.displayedData).toEqual([data.c, data.b, data.a]);
     component.onSortChange(columns[0]);
     expect(component.sortDirection).toBe(SortDirection.ascending);
-    expect(component.filteredData).toEqual([data.a, data.b, data.c]);
+    expect(component.displayedData).toEqual([data.a, data.b, data.c]);
   });
 
   it('should sort new sorting header always ascending first', () => {
     component.sortDirection = SortDirection.descending;
     fixture.detectChanges();
     component.onSortChange(columns[1]);
-    expect(component.filteredData).toEqual([data.c, data.a, data.b]);
+    expect(component.displayedData).toEqual([data.c, data.a, data.b]);
   });
 
   it('should highlight which column is sorted and in which direction', () => {
@@ -127,7 +127,7 @@ describe('DatatableComponent', () => {
   it('should use a different compare property', () => {
     component.columns[0].compareProp = 'hidden';
     fixture.detectChanges();
-    expect(component.filteredData).toEqual([data.b, data.c, data.a]);
+    expect(component.displayedData).toEqual([data.b, data.c, data.a]);
   });
 
   it('should find nested property names', () => {
@@ -136,14 +136,14 @@ describe('DatatableComponent', () => {
     fh.clickElement('thead > tr > th:nth-child(2)');
     fh.expectTextToBe('.sort-header.asc', 'Bar');
     expect(component.sortHeader).toBe('inside.color');
-    expect(component.filteredData).toEqual([data.a, data.c, data.b]);
+    expect(component.displayedData).toEqual([data.a, data.c, data.b]);
   });
 
   // This resolve the issue that the action menu closes on data refresh without a seen change.
   it('should cache the current view', () => {
     fixture.detectChanges();
-    const oldTableData = component.filteredData;
+    const oldTableData = component.displayedData;
     component.data = [data.c, data.b, data.a];
-    expect(oldTableData).toBe(component.filteredData);
+    expect(oldTableData).toBe(component.displayedData);
   });
 });


### PR DESCRIPTION
Additionally reset current page when clearing the search filter.

Fixes: https://github.com/aquarist-labs/s3gw/issues/559

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
