### PR TITLE
backend: add admin ops (skeleton) support

### DIFF
--- a/src/backend/admin_ops/__init__.py
+++ b/src/backend/admin_ops/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict
+
+import httpx
+from botocore.auth import HmacV1Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+
+
+def signed_request(
+    *,
+    access: str,
+    secret: str,
+    method: str,
+    url: str,
+    data: Dict[str, Any] | None = None,
+    params: Dict[str, Any] | None = None,
+    headers: Dict[str, Any] | None = None,
+) -> httpx.Request:
+    """
+    Returns a request signed with AWS HMAC v1 Auth (SHA1), which is what is
+    understood by RGW's admin ops authentication.
+    """
+    creds = Credentials(access, secret)
+    awsreq = AWSRequest(
+        method=method, url=url, data=data, params=params, headers=headers
+    )
+    # NOTE(jecluis): it seems that query parameters are not considered for the
+    # signature, unless they are provided via the URL, and always with a '/'
+    # after the base URL:port address. E.g., http://foo.bar:123/?param1=baz
+    # works, whereas http://foo.bar:123?param1=baz does not.
+    #
+    HmacV1Auth(credentials=creds).add_auth(awsreq)
+
+    return httpx.Request(
+        method=method,
+        url=url,
+        params=awsreq.params,
+        data=awsreq.data,
+        headers=dict(awsreq.headers),
+    )

--- a/src/backend/admin_ops/buckets.py
+++ b/src/backend/admin_ops/buckets.py
@@ -1,0 +1,63 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, TypedDict
+
+import httpx
+from pydantic import parse_obj_as
+
+from backend.admin_ops import signed_request
+from backend.admin_ops.types import AdminOpsError, Bucket
+
+
+class OptionalUIDParam(TypedDict, total=False):
+    uid: str
+
+
+class BucketListParams(OptionalUIDParam):
+    stats: bool
+
+
+async def list(
+    url: str,
+    access_key: str,
+    secret_key: str,
+    uid: str | None = None,
+) -> List[Bucket]:
+    """
+    Obtains a list of `Bucket`, containing a multitude of information about each
+    bucket available in the system. If `uid` is specified, returns only those
+    buckets owned by the specified user id.
+    """
+    params: BucketListParams = {
+        "stats": True,
+    }
+    if uid is not None and len(uid) > 0:
+        params["uid"] = uid
+
+    req = signed_request(
+        access=access_key,
+        secret=secret_key,
+        method="GET",
+        url=f"{url}/admin/bucket",
+        params=dict(params),
+        headers={"Accept": "application/json"},
+    )
+
+    async with httpx.AsyncClient() as client:
+        res: httpx.Response = await client.send(req)
+        if not res.is_success:
+            raise AdminOpsError(res.status_code)
+
+        return parse_obj_as(List[Bucket], res.json())

--- a/src/backend/admin_ops/errors.py
+++ b/src/backend/admin_ops/errors.py
@@ -17,43 +17,10 @@ from typing import Any, Dict
 
 import httpx
 
-
-class AdminOpsError(Exception):
-    _msg: str | None
-    _code: int
-
-    def __init__(self, code: int, msg: str | None = None) -> None:
-        self._msg = msg
-        self._code = code
-
-    @property
-    def msg(self) -> str:
-        return self._msg if self._msg is not None else ""
-
-    @property
-    def code(self) -> int:
-        return self._code
-
-    def __str__(self) -> str:
-        return f"Error ({self.code}): {self.msg}"
+from backend.s3gw.errors import S3GWError, error_from_code
 
 
-class UserAlreadyExistsError(AdminOpsError):
-    def __init__(self, code: int) -> None:
-        super().__init__(code, msg="User Already Exists")
-
-
-class UserDoesNotExistError(AdminOpsError):
-    def __init__(self, code: int) -> None:
-        super().__init__(code, msg="User Does Not Exist")
-
-
-class AccessKeyDoesNotExistError(AdminOpsError):
-    def __init__(self, code: int) -> None:
-        super().__init__(code, msg="Access Key ID Does Not Exist")
-
-
-def error_from_response(res: httpx.Response) -> AdminOpsError:
+def error_from_response(res: httpx.Response) -> S3GWError:
     """Translates an error response from the admin ops API to an exception."""
     assert not res.is_success
 
@@ -63,20 +30,10 @@ def error_from_response(res: httpx.Response) -> AdminOpsError:
     except JSONDecodeError:
         pass
 
-    if error is None or "Code" not in error:
-        return AdminOpsError(res.status_code)
-
-    code: str = error["Code"]
-
-    match code:
-        case "UserAlreadyExists":
-            return UserAlreadyExistsError(res.status_code)
-        case "NoSuchUser":
-            return UserDoesNotExistError(res.status_code)
-        case "InvalidAccessKeyId":
-            return AccessKeyDoesNotExistError(res.status_code)
-        case _:
-            return AdminOpsError(res.status_code, msg=code)
+    code: str = (
+        "Unknown" if error is None or "Code" not in error else error["Code"]
+    )
+    return error_from_code(code)
 
 
 class MissingParameterError(Exception):

--- a/src/backend/admin_ops/errors.py
+++ b/src/backend/admin_ops/errors.py
@@ -1,0 +1,89 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from json import JSONDecodeError
+from typing import Any, Dict
+
+import httpx
+
+
+class AdminOpsError(Exception):
+    _msg: str | None
+    _code: int
+
+    def __init__(self, code: int, msg: str | None = None) -> None:
+        self._msg = msg
+        self._code = code
+
+    @property
+    def msg(self) -> str:
+        return self._msg if self._msg is not None else ""
+
+    @property
+    def code(self) -> int:
+        return self._code
+
+    def __str__(self) -> str:
+        return f"Error ({self.code}): {self.msg}"
+
+
+class UserAlreadyExistsError(AdminOpsError):
+    def __init__(self, code: int) -> None:
+        super().__init__(code, msg="User Already Exists")
+
+
+class UserDoesNotExistError(AdminOpsError):
+    def __init__(self, code: int) -> None:
+        super().__init__(code, msg="User Does Not Exist")
+
+
+class AccessKeyDoesNotExistError(AdminOpsError):
+    def __init__(self, code: int) -> None:
+        super().__init__(code, msg="Access Key ID Does Not Exist")
+
+
+def error_from_response(res: httpx.Response) -> AdminOpsError:
+    """Translates an error response from the admin ops API to an exception."""
+    assert not res.is_success
+
+    error: Dict[str, Any] | None = None
+    try:
+        error = res.json()
+    except JSONDecodeError:
+        pass
+
+    if error is None or "Code" not in error:
+        return AdminOpsError(res.status_code)
+
+    code: str = error["Code"]
+
+    match code:
+        case "UserAlreadyExists":
+            return UserAlreadyExistsError(res.status_code)
+        case "NoSuchUser":
+            return UserDoesNotExistError(res.status_code)
+        case "InvalidAccessKeyId":
+            return AccessKeyDoesNotExistError(res.status_code)
+        case _:
+            return AdminOpsError(res.status_code, msg=code)
+
+
+class MissingParameterError(Exception):
+    _param: str
+
+    def __init__(self, param: str) -> None:
+        self._param = param
+
+    def __str__(self) -> str:
+        return f"Missing parameter: {self._param}"

--- a/src/backend/admin_ops/types.py
+++ b/src/backend/admin_ops/types.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime as dt
-from typing import Any, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 from types_aiobotocore_s3.literals import ObjectLockRetentionModeType
@@ -105,6 +105,14 @@ class UserQuotaOpParams(ParamsModel):
     max_size: Optional[int] = Field(default=None)
     quota_type: Literal["user"] | Literal["bucket"]
     enabled: bool
+
+
+def params_model_to_params(model: ParamsModel) -> Dict[str, Any]:
+    """
+    Translates a `ParamsModel` class to a dictionary we can consume as
+    parameters for an admin ops api request.
+    """
+    return {k: v for k, v in model.dict(by_alias=True).items() if v is not None}
 
 
 class Bucket(BaseModel):

--- a/src/backend/admin_ops/types.py
+++ b/src/backend/admin_ops/types.py
@@ -20,29 +20,22 @@ from types_aiobotocore_s3.literals import ObjectLockRetentionModeType
 from types_aiobotocore_s3.type_defs import TagTypeDef
 
 
-class AdminOpsError(Exception):
-    _msg: str | None
-    _code: int
-
-    def __init__(self, code: int, msg: str | None = None) -> None:
-        self._msg = msg
-        self._code = code
-
-    @property
-    def msg(self) -> str:
-        return self._msg if self._msg is not None else ""
-
-    @property
-    def code(self) -> int:
-        return self._code
-
-
 class QuotaInfo(BaseModel):
     enabled: bool
     check_on_raw: bool
     max_size: int
     max_size_kb: int
     max_objects: int
+
+
+class UserStatistics(BaseModel):
+    size: int
+    size_actual: int
+    size_utilized: int
+    size_kb: int
+    size_kb_actual: int
+    size_kb_utilized: int
+    num_objects: int
 
 
 class UserKeys(BaseModel):
@@ -66,6 +59,52 @@ class UserInfo(BaseModel):
     admin: bool
     bucket_quota: QuotaInfo
     user_quota: QuotaInfo
+    stats: Optional[UserStatistics]
+
+
+class AuthUser(BaseModel):
+    user_id: str
+    display_name: str
+    is_admin: bool
+
+
+def to_dashes(s: str) -> str:
+    return s.replace("_", "-")
+
+
+class ParamsModel(BaseModel):
+    class Config:
+        alias_generator = to_dashes
+        allow_population_by_field_name = True
+
+
+class UserOpParams(ParamsModel):
+    uid: str
+    display_name: Optional[str] = Field(default=None)
+    email: Optional[str] = Field(default=None)
+    key_type: Optional[Literal["s3"]] = Field(default=None)
+    access_key: Optional[str] = Field(default=None)
+    secret_key: Optional[str] = Field(default=None)
+    user_caps: Optional[str] = Field(default=None)
+    generate_key: Optional[bool] = Field(default=None)
+    max_buckets: Optional[int] = Field(default=None)
+    suspended: Optional[bool] = Field(default=None)
+    tenant: Optional[str] = Field(default=None)
+
+
+class UserKeyOpParams(ParamsModel):
+    uid: str
+    key_type: Optional[Literal["s3"]] = Field(default=None)
+    access_key: Optional[str] = Field(default=None)
+    secret_key: Optional[str] = Field(default=None)
+    generate_key: Optional[bool] = Field(default=None)
+
+
+class UserQuotaOpParams(ParamsModel):
+    max_objects: Optional[int] = Field(default=None)
+    max_size: Optional[int] = Field(default=None)
+    quota_type: Literal["user"] | Literal["bucket"]
+    enabled: bool
 
 
 class Bucket(BaseModel):

--- a/src/backend/admin_ops/types.py
+++ b/src/backend/admin_ops/types.py
@@ -45,6 +45,29 @@ class QuotaInfo(BaseModel):
     max_objects: int
 
 
+class UserKeys(BaseModel):
+    user: str
+    access_key: str
+    secret_key: str
+
+
+class UserInfo(BaseModel):
+    tenant: str
+    user_id: str
+    display_name: str
+    email: str
+    suspended: bool
+    max_buckets: int
+    subusers: List[Any]
+    keys: List[UserKeys]
+    caps: List[Any]
+    op_mask: str
+    system: bool
+    admin: bool
+    bucket_quota: QuotaInfo
+    user_quota: QuotaInfo
+
+
 class Bucket(BaseModel):
     id: str
     bucket: str

--- a/src/backend/admin_ops/types.py
+++ b/src/backend/admin_ops/types.py
@@ -1,0 +1,69 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime as dt
+from typing import Any, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+from types_aiobotocore_s3.literals import ObjectLockRetentionModeType
+from types_aiobotocore_s3.type_defs import TagTypeDef
+
+
+class AdminOpsError(Exception):
+    _msg: str | None
+    _code: int
+
+    def __init__(self, code: int, msg: str | None = None) -> None:
+        self._msg = msg
+        self._code = code
+
+    @property
+    def msg(self) -> str:
+        return self._msg if self._msg is not None else ""
+
+    @property
+    def code(self) -> int:
+        return self._code
+
+
+class QuotaInfo(BaseModel):
+    enabled: bool
+    check_on_raw: bool
+    max_size: int
+    max_size_kb: int
+    max_objects: int
+
+
+class Bucket(BaseModel):
+    id: str
+    bucket: str
+    owner: str
+    marker: str
+    index_type: str
+    ver: str
+    master_ver: str
+    mtime: dt
+    creation_time: dt
+    max_marker: str
+    usage: Any
+    bucket_quota: QuotaInfo
+
+    # optional fields
+    tags: Optional[List[TagTypeDef]] = None
+    versioning_enabled: bool = Field(default=False)
+    object_lock_enabled: bool = Field(default=False)
+    retention_enabled: bool = Field(default=False)
+    retention_mode: Optional[ObjectLockRetentionModeType] = None
+    retention_validity: Optional[int] = None
+    retention_unit: Optional[Literal["Days"] | Literal["Years"]] = None

--- a/src/backend/admin_ops/users.py
+++ b/src/backend/admin_ops/users.py
@@ -1,0 +1,39 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httpx
+
+from backend.admin_ops import signed_request
+from backend.admin_ops.types import AdminOpsError, UserInfo
+
+
+async def get_user_info(url: str, access_key: str, secret_key: str) -> UserInfo:
+    """
+    Obtain informations about the user to whom the `access_key:secret_key` pair
+    belongs to.
+    """
+    req = signed_request(
+        access=access_key,
+        secret=secret_key,
+        method="GET",
+        url=f"{url}/admin/user",
+        params={"access-key": access_key},
+    )
+
+    async with httpx.AsyncClient() as client:
+        res: httpx.Response = await client.send(req)
+        if not res.is_success:
+            raise AdminOpsError(res.status_code)
+
+        return UserInfo.parse_obj(res.json())

--- a/src/backend/admin_ops/users.py
+++ b/src/backend/admin_ops/users.py
@@ -12,28 +12,270 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+from typing import Any, Dict, List, Literal, cast
+
 import httpx
+from pydantic import parse_obj_as
 
 from backend.admin_ops import signed_request
-from backend.admin_ops.types import AdminOpsError, UserInfo
+from backend.admin_ops.errors import MissingParameterError, error_from_response
+from backend.admin_ops.types import (
+    AuthUser,
+    ParamsModel,
+    UserInfo,
+    UserKeyOpParams,
+    UserKeys,
+    UserOpParams,
+    UserQuotaOpParams,
+)
 
 
-async def get_user_info(url: str, access_key: str, secret_key: str) -> UserInfo:
+def _model_to_params(model: ParamsModel) -> Dict[str, Any]:
     """
-    Obtain informations about the user to whom the `access_key:secret_key` pair
-    belongs to.
+    Translates a `UserOpParams` class to a dictionary we can consume as
+    parameters for an admin ops api request.
     """
+    return {k: v for k, v in model.dict(by_alias=True).items() if v is not None}
+
+
+HTTPMethodType = (
+    Literal["GET"] | Literal["POST"] | Literal["PUT"] | Literal["DELETE"]
+)
+
+
+async def _do_request(
+    *,
+    url: str,
+    access_key: str,
+    secret_key: str,
+    endpoint: str,
+    method: HTTPMethodType,
+    params: Dict[str, Any] | None = None,
+) -> httpx.Response:
+    ep = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+
     req = signed_request(
         access=access_key,
         secret=secret_key,
-        method="GET",
-        url=f"{url}/admin/user",
-        params={"access-key": access_key},
+        method=method,
+        url=f"{url}{ep}",
+        params=params,
     )
 
     async with httpx.AsyncClient() as client:
         res: httpx.Response = await client.send(req)
         if not res.is_success:
-            raise AdminOpsError(res.status_code)
+            raise error_from_response(res)
 
-        return UserInfo.parse_obj(res.json())
+        return res
+
+
+async def get_user_info(
+    url: str,
+    access_key: str,
+    secret_key: str,
+    uid: str | None = None,
+    with_statistics: bool = False,
+) -> UserInfo:
+    """
+    Obtain informations about the user to whom the `access_key:secret_key` pair
+    belongs to.
+    """
+    params = {"access-key": access_key, "stats": with_statistics}
+    if uid is not None and len(uid) > 0:
+        params["uid"] = uid
+
+    res = await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint="/admin/user",
+        method="GET",
+        params=params,
+    )
+    return UserInfo.parse_obj(res.json())
+
+
+async def get_auth_user(url: str, access_key: str, secret_key: str) -> AuthUser:
+    """
+    Check if the given credentials are valid and whether the user is allowed
+    access to the admin ops API.
+    """
+    info = await get_user_info(url, access_key, secret_key)
+    return AuthUser(
+        user_id=info.user_id,
+        display_name=info.display_name,
+        is_admin=info.admin,
+    )
+
+
+async def list_uids(url: str, access_key: str, secret_key: str) -> List[str]:
+    """Obtain a list of all user ids."""
+
+    res = await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        method="GET",
+        endpoint="/admin/metadata/user",
+    )
+    lst: Any = res.json()
+    assert isinstance(lst, list)
+    return cast(List[str], lst)
+
+
+async def list_users(
+    url: str, access_key: str, secret_key: str, with_statistics: bool = False
+) -> List[UserInfo]:
+    """
+    Obtain a list of users, by first performing a `list_uids()` operation, and
+    then, for each `uid` returned, obtains said `uid` user info by running
+    `get_user_info()` in parallel. For a large enough number of `uids`, this
+    operation's complexity is non-negligible.
+    """
+
+    uids = await list_uids(url, access_key, secret_key)
+    assert len(uids) > 0
+
+    requests = [
+        get_user_info(
+            url,
+            access_key,
+            secret_key,
+            uid=uid,
+            with_statistics=with_statistics,
+        )
+        for uid in uids
+    ]
+
+    uinfo_lst: List[UserInfo] = await asyncio.gather(
+        *requests, return_exceptions=True
+    )
+    assert len(uinfo_lst) > 0
+    return uinfo_lst
+
+
+async def create(
+    url: str, access_key: str, secret_key: str, user: UserOpParams
+) -> UserInfo:
+    """Creates a new user, as specified by the `user` argument."""
+
+    if user.display_name is None:
+        raise MissingParameterError("display name")
+
+    user.key_type = "s3"
+
+    params: Dict[str, Any] = _model_to_params(user)
+
+    res = await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint="/admin/user",
+        method="PUT",
+        params=params,
+    )
+    return UserInfo.parse_obj(res.json())
+
+
+async def delete(url: str, access_key: str, secret_key: str, uid: str) -> None:
+    """Deletes a user, specified by `uid`."""
+
+    params = {"uid": uid}
+    await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint="/admin/user",
+        method="DELETE",
+        params=params,
+    )
+
+
+async def update(
+    url: str, access_key: str, secret_key: str, user: UserOpParams
+) -> UserInfo:
+    """Modifies a user, setting the values specified by `user`."""
+
+    params: Dict[str, Any] = _model_to_params(user)
+    res = await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint="/admin/user",
+        method="POST",
+        params=params,
+    )
+    return UserInfo.parse_obj(res.json())
+
+
+async def create_key(
+    url: str, access_key: str, secret_key: str, key_params: UserKeyOpParams
+) -> List[UserKeys]:
+    """Creates a new key for a user specified in `key_params`."""
+
+    params: Dict[str, Any] = _model_to_params(key_params)
+    res = await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint="/admin/user?key",
+        method="PUT",
+        params=params,
+    )
+    return parse_obj_as(List[UserKeys], res.json())
+
+
+async def get_keys(
+    url: str, access_key: str, secret_key: str, uid: str
+) -> List[UserKeys]:
+    """Obtain all keys for a given user."""
+
+    user = await get_user_info(url, access_key, secret_key, uid)
+    return user.keys
+
+
+async def delete_key(
+    url: str,
+    access_key: str,
+    secret_key: str,
+    uid: str,
+    user_access_key: str,
+) -> None:
+    """Deletes the key `user_access_key` from user `uid`."""
+
+    params: Dict[str, str] = {"uid": uid, "access-key": user_access_key}
+    await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint="/admin/user?key",
+        method="DELETE",
+        params=params,
+    )
+
+
+async def quota_update(
+    url: str,
+    access_key: str,
+    secret_key: str,
+    uid: str,
+    quota: UserQuotaOpParams,
+) -> None:
+    """Updates user's `uid` quota to `quota`."""
+
+    assert quota.quota_type is not None
+    assert quota.quota_type == "user"
+
+    params: Dict[str, Any] = _model_to_params(quota)
+    params["uid"] = uid
+
+    await _do_request(
+        url=url,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint="/admin/user?quota",
+        method="PUT",
+        params=params,
+    )

--- a/src/backend/s3gw/client.py
+++ b/src/backend/s3gw/client.py
@@ -1,0 +1,97 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+from typing import AsyncGenerator, cast
+
+from aiobotocore.session import AioSession
+from botocore.config import Config as S3Config
+from botocore.exceptions import ClientError, EndpointConnectionError, SSLError
+from fastapi import HTTPException
+from fastapi.logger import logger
+from types_aiobotocore_s3.client import S3Client
+
+from backend.s3gw.errors import (
+    EndpointNotFoundError,
+    S3GWError,
+    SSLNotSupported,
+    decode_client_error,
+)
+
+
+class S3GWClient:
+    """
+    Represents a client connection to an s3gw server.
+
+    A connection is not opened by this class. Instead, a client is created when
+    requesting a connection via the `conn()` context manager, and the connection
+    is handled by the `aiobotocore's S3Client` class that is returned.
+    """
+
+    _endpoint: str
+    _access_key: str
+    _secret_key: str
+
+    def __init__(self, endpoint: str, access_key: str, secret_key: str) -> None:
+        """
+        Creates a new `S3GWClient` instance.
+
+        Arguments:
+        * `endpoint`: the URL where the server is expected to be at.
+        * `access_key`: the user's `access key`.
+        * `secret_key`: the user's `secret access key`.
+        """
+        self._endpoint = endpoint
+        self._access_key = access_key
+        self._secret_key = secret_key
+
+    @contextlib.asynccontextmanager
+    async def conn(self, attempts: int = 1) -> AsyncGenerator[S3Client, None]:
+        """
+        Yields an `aiobotocore's S3Client` instance, that can be used to
+        perform operations against an S3-compatible server. In case of failure,
+        by default, the operation only performs one attempt.
+
+        This context manager will catch most exceptions thrown by the
+        `S3Client`'s operations, and convert them to `fastapi.HTTPException`.
+        """
+        session = AioSession()
+        async with session.create_client(
+            "s3",
+            endpoint_url=self._endpoint,
+            aws_access_key_id=self._access_key,
+            aws_secret_access_key=self._secret_key,
+            config=S3Config(
+                retries={
+                    "max_attempts": attempts,
+                    "mode": "standard",
+                }
+            ),
+        ) as client:
+            try:
+                yield cast(S3Client, client)
+            except ClientError as e:
+                raise decode_client_error(e)
+            except EndpointConnectionError as e:
+                raise EndpointNotFoundError()
+            except SSLError as e:
+                raise SSLNotSupported()
+            except HTTPException as e:
+                # probably an error raised by yielded client context; lets
+                # propagate it.
+                raise e
+            except Exception as e:
+                logger.error(f"Unknown error: {e}")
+                logger.error(f"  exception: {type(e)}")
+                raise S3GWError(code=500, msg=str(e))

--- a/src/backend/s3gw/errors.py
+++ b/src/backend/s3gw/errors.py
@@ -1,0 +1,97 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from botocore.exceptions import ClientError
+from fastapi import status
+
+
+class S3GWError(Exception):
+    _msg: str | None
+    _code: int
+
+    def __init__(self, code: int, msg: str | None = None) -> None:
+        self._msg = msg
+        self._code = code
+
+    @property
+    def msg(self) -> str:
+        return self._msg if self._msg is not None else ""
+
+    @property
+    def code(self) -> int:
+        return self._code
+
+    def __str__(self) -> str:
+        return f"Error ({self.code}): {self.msg}"
+
+
+class UserAlreadyExistsError(S3GWError):
+    def __init__(self, code: int) -> None:
+        super().__init__(code, msg="User Already Exists")
+
+
+class UserDoesNotExistError(S3GWError):
+    def __init__(self, code: int) -> None:
+        super().__init__(code, msg="User Does Not Exist")
+
+
+class AccessKeyDoesNotExistError(S3GWError):
+    def __init__(self, code: int) -> None:
+        super().__init__(code, msg="Access Key ID Does Not Exist")
+
+
+class EndpointNotFoundError(S3GWError):
+    def __init__(self) -> None:
+        super().__init__(status.HTTP_502_BAD_GATEWAY, msg="Endpoint not found")
+
+
+class SSLNotSupported(S3GWError):
+    def __init__(self) -> None:
+        super().__init__(
+            status.HTTP_501_NOT_IMPLEMENTED, msg="SSL not supported"
+        )
+
+
+def error_from_code(code_str: str, code: int | None = None) -> S3GWError:
+    match code_str:
+        case "UserAlreadyExists":
+            code = code if code is not None else status.HTTP_409_CONFLICT
+            return UserAlreadyExistsError(code=code)
+        case "NoSuchUser":
+            code = code if code is not None else status.HTTP_404_NOT_FOUND
+            return UserDoesNotExistError(code=code)
+        case "InvalidAccessKeyId":
+            code = code if code is not None else status.HTTP_401_UNAUTHORIZED
+            return AccessKeyDoesNotExistError(code=code)
+        case _:
+            code = (
+                code
+                if code is not None
+                else status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+            return S3GWError(code=code, msg=f"Unknown Error '{code_str}'")
+
+
+def decode_client_error(e: ClientError) -> S3GWError:
+    """
+    Returns a tuple of `(status_code, error_message)` according to the
+    `botocore's ClientError` exception thas is passed as an argument.
+    """
+    code_str = "Unknown"
+
+    if "Error" in e.response:
+        if "Code" in e.response["Error"]:
+            code_str = e.response["Error"]["Code"]
+
+    return error_from_code(code_str)

--- a/src/backend/tests/admin_ops/test_admin_ops.py
+++ b/src/backend/tests/admin_ops/test_admin_ops.py
@@ -1,0 +1,78 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import httpx
+import pytest
+
+from backend.admin_ops import signed_request
+
+
+@pytest.mark.anyio
+async def test_signed_request() -> None:
+    authorization_regex = re.compile(r"^[ ]*AWS[ ]+(\w+):([\w_/=+]+)")
+
+    req1: httpx.Request = signed_request(
+        access="test",
+        secret="test",
+        method="GET",
+        url="http://foo.bar:123",
+        data=None,
+        params=None,
+        headers=None,
+    )
+    assert "Authorization" in req1.headers
+    m1 = re.fullmatch(authorization_regex, req1.headers["Authorization"])
+    assert m1 is not None
+    assert len(m1.groups()) == 2
+    assert m1.group(1) == "test"
+    assert len(m1.group(2)) > 0
+
+    req2: httpx.Request = signed_request(
+        access="test",
+        secret="test",
+        method="POST",
+        url="http://foo.bar:123",
+        data=None,
+        params=None,
+        headers=None,
+    )
+    assert "Authorization" in req2.headers
+    m2 = re.fullmatch(authorization_regex, req2.headers["Authorization"])
+    print(req2.headers["Authorization"])
+    assert m2 is not None
+    assert len(m2.groups()) == 2
+    assert m2.group(1) == "test"
+    assert len(m2.group(2)) > 0
+    assert m2.group(2) != m1.group(2)
+
+    req3: httpx.Request = signed_request(
+        access="test",
+        secret="test",
+        method="GET",
+        url="http://foo.bar:123/?param1=baz",
+        data=None,
+        params=None,
+        headers=None,
+    )
+    assert "Authorization" in req3.headers
+    m3 = re.fullmatch(authorization_regex, req3.headers["Authorization"])
+    assert m3 is not None
+    assert len(m3.groups()) == 2
+    assert m3.group(1) == "test"
+    assert len(m3.group(2)) > 0
+    assert m3.group(2) != m1.group(2)
+    assert m3.group(2) != m2.group(2)
+    assert str(req3.url.query).find("param1=baz") >= 0

--- a/src/backend/tests/admin_ops/test_buckets.py
+++ b/src/backend/tests/admin_ops/test_buckets.py
@@ -19,8 +19,8 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from backend.admin_ops.buckets import list
-from backend.admin_ops.errors import AdminOpsError
 from backend.admin_ops.types import Bucket
+from backend.s3gw.errors import S3GWError
 
 bucket_list_response: List[Dict[str, Any]] = [
     {
@@ -116,7 +116,7 @@ async def test_bucket_list_failure(httpx_mock: HTTPXMock) -> None:
             secret_key="qwe",
             uid=None,
         )
-    except AdminOpsError:
+    except S3GWError:
         raised = True
 
     assert raised

--- a/src/backend/tests/admin_ops/test_buckets.py
+++ b/src/backend/tests/admin_ops/test_buckets.py
@@ -1,0 +1,149 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from backend.admin_ops.buckets import list
+from backend.admin_ops.types import AdminOpsError, Bucket
+
+bucket_list_response: List[Dict[str, Any]] = [
+    {
+        "bucket": "foo",
+        "num_shards": 1,
+        "tenant": "",
+        "zonegroup": "",
+        "placement_rule": "default",
+        "explicit_placement": {
+            "data_pool": "",
+            "data_extra_pool": "",
+            "index_pool": "",
+        },
+        "id": "foo.1681284188914692706",
+        "marker": "foo.1681284188914692706",
+        "index_type": "Normal",
+        "owner": "testid",
+        "ver": "",
+        "master_ver": "",
+        "mtime": "0.000000",
+        "creation_time": "2023-04-12T07:23:08.914692Z",
+        "max_marker": "",
+        "usage": {},
+        "bucket_quota": {
+            "enabled": False,
+            "check_on_raw": False,
+            "max_size": -1,
+            "max_size_kb": 0,
+            "max_objects": -1,
+        },
+    },
+    {
+        "bucket": "bar",
+        "num_shards": 1,
+        "tenant": "",
+        "zonegroup": "",
+        "placement_rule": "default",
+        "explicit_placement": {
+            "data_pool": "",
+            "data_extra_pool": "",
+            "index_pool": "",
+        },
+        "id": "bar.168128418863559658",
+        "marker": "bar.168128418863559658",
+        "index_type": "Normal",
+        "owner": "testid",
+        "ver": "",
+        "master_ver": "",
+        "mtime": "0.000000",
+        "creation_time": "2023-04-12T07:23:08.063559Z",
+        "max_marker": "",
+        "usage": {},
+        "bucket_quota": {
+            "enabled": False,
+            "check_on_raw": False,
+            "max_size": -1,
+            "max_size_kb": 0,
+            "max_objects": -1,
+        },
+    },
+]
+
+
+@pytest.mark.anyio
+async def test_bucket_list(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(  # pyright: ignore [reportUnknownMemberType]
+        json=bucket_list_response,
+    )
+
+    res: List[Bucket] = await list(
+        url="http://foo.bar:123",
+        access_key="asd",
+        secret_key="qwe",
+        uid=None,
+    )
+
+    assert len(res) == 2
+    assert res[0].bucket == "foo"
+    assert res[1].bucket == "bar"
+
+
+@pytest.mark.anyio
+async def test_bucket_list_failure(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(  # pyright: ignore [reportUnknownMemberType]
+        status_code=404  # any error, really
+    )
+
+    raised = False
+    try:
+        await list(
+            url="http://foo.bar:123",
+            access_key="asd",
+            secret_key="qwe",
+            uid=None,
+        )
+    except AdminOpsError:
+        raised = True
+
+    assert raised
+
+
+@pytest.mark.anyio
+async def test_bucket_list_with_uid(httpx_mock: HTTPXMock) -> None:
+    called_cb = False
+
+    def check_uid(req: httpx.Request) -> httpx.Response:
+        nonlocal called_cb
+        called_cb = True
+        assert str(req.url.query).find("uid=asdasd") >= 0
+        return httpx.Response(status_code=200, json=bucket_list_response)
+
+    httpx_mock.add_callback(  # pyright: ignore [reportUnknownMemberType]
+        check_uid
+    )
+
+    res: List[Bucket] = await list(
+        url="http://foo.bar:123",
+        access_key="asd",
+        secret_key="qwe",
+        uid="asdasd",
+    )
+
+    assert len(res) == 2
+    assert res[0].bucket == "foo"
+    assert res[1].bucket == "bar"
+
+    assert called_cb

--- a/src/backend/tests/admin_ops/test_buckets.py
+++ b/src/backend/tests/admin_ops/test_buckets.py
@@ -19,7 +19,8 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from backend.admin_ops.buckets import list
-from backend.admin_ops.types import AdminOpsError, Bucket
+from backend.admin_ops.errors import AdminOpsError
+from backend.admin_ops.types import Bucket
 
 bucket_list_response: List[Dict[str, Any]] = [
     {

--- a/src/backend/tests/admin_ops/test_errors.py
+++ b/src/backend/tests/admin_ops/test_errors.py
@@ -1,0 +1,66 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httpx
+
+from backend.admin_ops.errors import (
+    AccessKeyDoesNotExistError,
+    AdminOpsError,
+    UserAlreadyExistsError,
+    UserDoesNotExistError,
+    error_from_response,
+)
+
+
+def test_errors_from_response() -> None:
+    errors = {
+        "UserAlreadyExists": UserAlreadyExistsError,
+        "NoSuchUser": UserDoesNotExistError,
+        "InvalidAccessKeyId": AccessKeyDoesNotExistError,
+    }
+
+    for err, exc in errors.items():
+        raised = False
+        res = httpx.Response(status_code=500, json={"Code": err})
+        try:
+            raise error_from_response(res)
+        except exc as e:
+            raised = True
+            assert type(e) != AdminOpsError
+        except Exception:
+            print(f"Failed handling error '{err}'")
+            assert False
+        assert raised
+
+    raised = False
+    res = httpx.Response(status_code=500)
+    try:
+        raise error_from_response(res)
+    except AdminOpsError as e:
+        raised = True
+        assert type(e) == AdminOpsError
+    except Exception:
+        assert False
+    assert raised
+
+    raised = False
+    res = httpx.Response(status_code=500, json={"Code": "Whatever"})
+    try:
+        raise error_from_response(res)
+    except AdminOpsError as e:
+        raised = True
+        assert type(e) == AdminOpsError
+    except Exception:
+        assert False
+    assert raised

--- a/src/backend/tests/admin_ops/test_errors.py
+++ b/src/backend/tests/admin_ops/test_errors.py
@@ -14,12 +14,12 @@
 
 import httpx
 
-from backend.admin_ops.errors import (
+from backend.admin_ops.errors import error_from_response
+from backend.s3gw.errors import (
     AccessKeyDoesNotExistError,
-    AdminOpsError,
+    S3GWError,
     UserAlreadyExistsError,
     UserDoesNotExistError,
-    error_from_response,
 )
 
 
@@ -37,7 +37,7 @@ def test_errors_from_response() -> None:
             raise error_from_response(res)
         except exc as e:
             raised = True
-            assert type(e) != AdminOpsError
+            assert type(e) != S3GWError
         except Exception:
             print(f"Failed handling error '{err}'")
             assert False
@@ -47,9 +47,9 @@ def test_errors_from_response() -> None:
     res = httpx.Response(status_code=500)
     try:
         raise error_from_response(res)
-    except AdminOpsError as e:
+    except S3GWError as e:
         raised = True
-        assert type(e) == AdminOpsError
+        assert type(e) == S3GWError
     except Exception:
         assert False
     assert raised
@@ -58,9 +58,9 @@ def test_errors_from_response() -> None:
     res = httpx.Response(status_code=500, json={"Code": "Whatever"})
     try:
         raise error_from_response(res)
-    except AdminOpsError as e:
+    except S3GWError as e:
         raised = True
-        assert type(e) == AdminOpsError
+        assert type(e) == S3GWError
     except Exception:
         assert False
     assert raised

--- a/src/backend/tests/admin_ops/test_types.py
+++ b/src/backend/tests/admin_ops/test_types.py
@@ -1,0 +1,32 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from backend.admin_ops.types import UserKeyOpParams, params_model_to_params
+
+
+def test_params_model_to_params() -> None:
+    res = params_model_to_params(
+        UserKeyOpParams(
+            uid="foo",
+            key_type="s3",
+            access_key="bar",
+            secret_key="baz",
+            generate_key=True,
+        )
+    )
+    assert "uid" in res
+    assert "key-type" in res and res["key-type"] == "s3"
+    assert "access-key" in res and res["access-key"] == "bar"
+    assert "secret-key" in res and res["secret-key"] == "baz"
+    assert "generate-key" in res and res["generate-key"] == True

--- a/src/backend/tests/admin_ops/test_users.py
+++ b/src/backend/tests/admin_ops/test_users.py
@@ -30,7 +30,6 @@ from backend.admin_ops.types import (
     UserQuotaOpParams,
 )
 from backend.admin_ops.users import (
-    _model_to_params,
     create,
     create_key,
     delete,
@@ -42,24 +41,6 @@ from backend.admin_ops.users import (
     quota_update,
     update,
 )
-
-
-def test_model_to_params() -> None:
-    res = _model_to_params(
-        UserKeyOpParams(
-            uid="foo",
-            key_type="s3",
-            access_key="bar",
-            secret_key="baz",
-            generate_key=True,
-        )
-    )
-    assert "uid" in res
-    assert "key-type" in res and res["key-type"] == "s3"
-    assert "access-key" in res and res["access-key"] == "bar"
-    assert "secret-key" in res and res["secret-key"] == "baz"
-    assert "generate-key" in res and res["generate-key"] == True
-
 
 res_user_info_json = {
     "tenant": "",
@@ -147,7 +128,7 @@ async def test_list_uids(mocker: MockerFixture) -> None:
         assert params is None
         return httpx.Response(status_code=200, json=["foo", "bar"])
 
-    mocker.patch("backend.admin_ops.users._do_request", new=_mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", new=_mock_do_request)
     res = await list_uids("http://fail.tld", access_key="asd", secret_key="qwe")
     assert isinstance(res, list)
     assert len(res) == 2
@@ -241,7 +222,7 @@ async def test_create_user(mocker: MockerFixture) -> None:
         info.display_name = "Foo"
         return httpx.Response(status_code=200, json=info.dict())
 
-    mocker.patch("backend.admin_ops.users._do_request", new=_mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", new=_mock_do_request)
     res = await create(
         "http://fail.tld",
         access_key="asd",
@@ -275,7 +256,7 @@ async def test_delete_user(mocker: MockerFixture) -> None:
         assert "uid" in params and params["uid"] == "foo"
         return httpx.Response(status_code=200)
 
-    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", _mock_do_request)
     await delete(
         "http://fail.tld",
         access_key="asd",
@@ -313,7 +294,7 @@ async def test_update_user(mocker: MockerFixture) -> None:
             json=info.dict(),
         )
 
-    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", _mock_do_request)
     res = await update(
         "http://fail.tld",
         access_key="asd",
@@ -356,7 +337,7 @@ async def test_create_key(mocker: MockerFixture) -> None:
             ],
         )
 
-    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", _mock_do_request)
     res = await create_key(
         "http://fail.tld",
         access_key="asd",
@@ -401,7 +382,7 @@ async def test_get_user_keys(mocker: MockerFixture) -> None:
             json=info.dict(),
         )
 
-    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", _mock_do_request)
     res = await get_keys(
         "http://fail.tld", access_key="asd", secret_key="qwe", uid="foo"
     )
@@ -432,7 +413,7 @@ async def test_delete_user_key(mocker: MockerFixture) -> None:
         assert "access-key" in params and params["access-key"] == "asdasd"
         return httpx.Response(status_code=200)
 
-    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", _mock_do_request)
     await delete_key(
         "http://fail.tld",
         access_key="asd",
@@ -465,7 +446,7 @@ async def test_quota_update(mocker: MockerFixture) -> None:
         assert "enabled" in params and params["enabled"] == True
         return httpx.Response(status_code=200)
 
-    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    mocker.patch("backend.admin_ops.users.do_request", _mock_do_request)
     await quota_update(
         "http://fail.tld",
         access_key="asd",

--- a/src/backend/tests/admin_ops/test_users.py
+++ b/src/backend/tests/admin_ops/test_users.py
@@ -1,0 +1,87 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from backend.admin_ops.types import AdminOpsError, UserInfo
+from backend.admin_ops.users import get_user_info
+
+
+@pytest.mark.anyio
+async def test_get_user_info(httpx_mock: HTTPXMock) -> None:
+    res_json = {
+        "tenant": "",
+        "user_id": "testid",
+        "display_name": "M. Tester",
+        "email": "tester@ceph.com",
+        "suspended": 0,
+        "max_buckets": 1000,
+        "subusers": [],
+        "keys": [
+            {"user": "testid", "access_key": "test", "secret_key": "test"}
+        ],
+        "swift_keys": [],
+        "caps": [],
+        "op_mask": "read, write, delete",
+        "system": False,
+        "admin": True,
+        "default_placement": "",
+        "default_storage_class": "",
+        "placement_tags": [],
+        "bucket_quota": {
+            "enabled": False,
+            "check_on_raw": False,
+            "max_size": -1,
+            "max_size_kb": 0,
+            "max_objects": -1,
+        },
+        "user_quota": {
+            "enabled": False,
+            "check_on_raw": False,
+            "max_size": -1,
+            "max_size_kb": 0,
+            "max_objects": -1,
+        },
+        "temp_url_keys": [],
+        "type": "rgw",
+        "mfa_ids": [],
+    }
+
+    httpx_mock.add_response(  # pyright: ignore [reportUnknownMemberType]
+        json=res_json,
+    )
+
+    res: UserInfo = await get_user_info(
+        url="http://foo.bar:123", access_key="asd", secret_key="qwe"
+    )
+    assert res.user_id == "testid"
+    assert res.admin
+
+
+@pytest.mark.anyio
+async def test_get_user_info_failure(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(  # pyright: ignore [reportUnknownMemberType]
+        status_code=404,  # any error, really
+    )
+
+    raised = False
+    try:
+        await get_user_info(
+            url="http://foo.bar:123", access_key="asd", secret_key="qwe"
+        )
+    except AdminOpsError:
+        raised = True
+
+    assert raised

--- a/src/backend/tests/admin_ops/test_users.py
+++ b/src/backend/tests/admin_ops/test_users.py
@@ -12,55 +12,96 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pyright: reportPrivateUsage=false
+
+from typing import Any, Dict, List
+
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
+from pytest_mock import MockerFixture
 
-from backend.admin_ops.types import AdminOpsError, UserInfo
-from backend.admin_ops.users import get_user_info
+from backend.admin_ops.errors import AdminOpsError
+from backend.admin_ops.types import (
+    UserInfo,
+    UserKeyOpParams,
+    UserKeys,
+    UserOpParams,
+    UserQuotaOpParams,
+)
+from backend.admin_ops.users import (
+    _model_to_params,
+    create,
+    create_key,
+    delete,
+    delete_key,
+    get_keys,
+    get_user_info,
+    list_uids,
+    list_users,
+    quota_update,
+    update,
+)
+
+
+def test_model_to_params() -> None:
+    res = _model_to_params(
+        UserKeyOpParams(
+            uid="foo",
+            key_type="s3",
+            access_key="bar",
+            secret_key="baz",
+            generate_key=True,
+        )
+    )
+    assert "uid" in res
+    assert "key-type" in res and res["key-type"] == "s3"
+    assert "access-key" in res and res["access-key"] == "bar"
+    assert "secret-key" in res and res["secret-key"] == "baz"
+    assert "generate-key" in res and res["generate-key"] == True
+
+
+res_user_info_json = {
+    "tenant": "",
+    "user_id": "testid",
+    "display_name": "M. Tester",
+    "email": "tester@ceph.com",
+    "suspended": 0,
+    "max_buckets": 1000,
+    "subusers": [],
+    "keys": [{"user": "testid", "access_key": "test", "secret_key": "test"}],
+    "swift_keys": [],
+    "caps": [],
+    "op_mask": "read, write, delete",
+    "system": False,
+    "admin": True,
+    "default_placement": "",
+    "default_storage_class": "",
+    "placement_tags": [],
+    "bucket_quota": {
+        "enabled": False,
+        "check_on_raw": False,
+        "max_size": -1,
+        "max_size_kb": 0,
+        "max_objects": -1,
+    },
+    "user_quota": {
+        "enabled": False,
+        "check_on_raw": False,
+        "max_size": -1,
+        "max_size_kb": 0,
+        "max_objects": -1,
+    },
+    "temp_url_keys": [],
+    "type": "rgw",
+    "mfa_ids": [],
+}
 
 
 @pytest.mark.anyio
 async def test_get_user_info(httpx_mock: HTTPXMock) -> None:
-    res_json = {
-        "tenant": "",
-        "user_id": "testid",
-        "display_name": "M. Tester",
-        "email": "tester@ceph.com",
-        "suspended": 0,
-        "max_buckets": 1000,
-        "subusers": [],
-        "keys": [
-            {"user": "testid", "access_key": "test", "secret_key": "test"}
-        ],
-        "swift_keys": [],
-        "caps": [],
-        "op_mask": "read, write, delete",
-        "system": False,
-        "admin": True,
-        "default_placement": "",
-        "default_storage_class": "",
-        "placement_tags": [],
-        "bucket_quota": {
-            "enabled": False,
-            "check_on_raw": False,
-            "max_size": -1,
-            "max_size_kb": 0,
-            "max_objects": -1,
-        },
-        "user_quota": {
-            "enabled": False,
-            "check_on_raw": False,
-            "max_size": -1,
-            "max_size_kb": 0,
-            "max_objects": -1,
-        },
-        "temp_url_keys": [],
-        "type": "rgw",
-        "mfa_ids": [],
-    }
-
     httpx_mock.add_response(  # pyright: ignore [reportUnknownMemberType]
-        json=res_json,
+        json=res_user_info_json,
     )
 
     res: UserInfo = await get_user_info(
@@ -85,3 +126,354 @@ async def test_get_user_info_failure(httpx_mock: HTTPXMock) -> None:
         raised = True
 
     assert raised
+
+
+@pytest.mark.anyio
+async def test_list_uids(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/metadata/user"
+        assert method == "GET"
+        assert params is None
+        return httpx.Response(status_code=200, json=["foo", "bar"])
+
+    mocker.patch("backend.admin_ops.users._do_request", new=_mock_do_request)
+    res = await list_uids("http://fail.tld", access_key="asd", secret_key="qwe")
+    assert isinstance(res, list)
+    assert len(res) == 2
+    assert "foo" in res
+    assert "bar" in res
+
+
+@pytest.mark.anyio
+async def test_list_users(mocker: MockerFixture) -> None:
+    async def _mock_get_user_info(
+        url: str,
+        access_key: str,
+        secret_key: str,
+        uid: str,
+        with_statistics: bool,
+    ) -> UserInfo:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert uid is not None and len(uid) > 0
+        assert not with_statistics
+        info = UserInfo.parse_obj(res_user_info_json)
+        info.user_id = uid
+        info.display_name = f"{uid} name"
+        info.email = f"{uid}@fail.tld"
+        return info
+
+    async def _mock_list_uids(
+        url: str, access_key: str, secret_key: str
+    ) -> List[str]:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        return ["foo", "bar"]
+
+    mocker.patch("backend.admin_ops.users.list_uids", new=_mock_list_uids)
+    mocker.patch(
+        "backend.admin_ops.users.get_user_info", new=_mock_get_user_info
+    )
+
+    res = await list_users(
+        "http://fail.tld",
+        access_key="asd",
+        secret_key="qwe",
+        with_statistics=False,
+    )
+    assert isinstance(res, list)
+    assert len(res) == 2
+    found_foo = False
+    found_bar = False
+    for entry in res:
+        if entry.user_id == "foo":
+            assert entry.email == "foo@fail.tld"
+            assert entry.display_name == "foo name"
+            found_foo = True
+        elif entry.user_id == "bar":
+            assert entry.email == "bar@fail.tld"
+            assert entry.display_name == "bar name"
+            found_bar = True
+        else:
+            assert False
+
+    assert found_foo
+    assert found_bar
+
+
+@pytest.mark.anyio
+async def test_create_user(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/user"
+        assert method == "PUT"
+        assert params is not None
+
+        assert "uid" in params and params["uid"] == "foo"
+        assert "display-name" in params and params["display-name"] == "Foo"
+        assert "key-type" in params and params["key-type"] == "s3"
+
+        info = UserInfo.parse_obj(res_user_info_json)
+        info.user_id = "foo"
+        info.display_name = "Foo"
+        return httpx.Response(status_code=200, json=info.dict())
+
+    mocker.patch("backend.admin_ops.users._do_request", new=_mock_do_request)
+    res = await create(
+        "http://fail.tld",
+        access_key="asd",
+        secret_key="qwe",
+        user=UserOpParams(
+            uid="foo",
+            display_name="Foo",
+        ),
+    )
+    assert res.user_id == "foo"
+    assert res.display_name == "Foo"
+
+
+@pytest.mark.anyio
+async def test_delete_user(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/user"
+        assert method == "DELETE"
+        assert params is not None
+        assert "uid" in params and params["uid"] == "foo"
+        return httpx.Response(status_code=200)
+
+    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    await delete(
+        "http://fail.tld",
+        access_key="asd",
+        secret_key="qwe",
+        uid="foo",
+    )
+
+
+@pytest.mark.anyio
+async def test_update_user(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/user"
+        assert method == "POST"
+        assert params is not None
+        assert "uid" in params and params["uid"] == "foo"
+        assert "email" in params and params["email"] == "foo@fail.tld"
+
+        info = UserInfo.parse_obj(res_user_info_json)
+        info.user_id = "foo"
+        info.email = "foo@fail.tld"
+
+        return httpx.Response(
+            status_code=200,
+            json=info.dict(),
+        )
+
+    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    res = await update(
+        "http://fail.tld",
+        access_key="asd",
+        secret_key="qwe",
+        user=UserOpParams(
+            uid="foo",
+            email="foo@fail.tld",
+        ),
+    )
+    assert res.user_id == "foo"
+    assert res.email == "foo@fail.tld"
+
+
+@pytest.mark.anyio
+async def test_create_key(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/user?key"
+        assert method == "PUT"
+        assert params is not None
+        assert "uid" in params and params["uid"] == "foo"
+        assert "generate-key" in params and params["generate-key"] == True
+
+        return httpx.Response(
+            status_code=200,
+            json=[
+                UserKeys(
+                    user="foo", access_key="asdasd", secret_key="qweqwe"
+                ).dict(),
+            ],
+        )
+
+    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    res = await create_key(
+        "http://fail.tld",
+        access_key="asd",
+        secret_key="qwe",
+        key_params=UserKeyOpParams(
+            uid="foo",
+            generate_key=True,
+        ),
+    )
+    assert len(res) == 1
+    assert res[0].user == "foo"
+    assert res[0].access_key == "asdasd"
+    assert res[0].secret_key == "qweqwe"
+
+
+@pytest.mark.anyio
+async def test_get_user_keys(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/user"
+        assert method == "GET"
+        assert params is not None
+        assert "uid" in params and params["uid"] == "foo"
+
+        info = UserInfo.parse_obj(res_user_info_json)
+        info.user_id = "foo"
+        info.keys = [
+            UserKeys(user="foo", access_key="asdasd", secret_key="qweqwe")
+        ]
+        return httpx.Response(
+            status_code=200,
+            json=info.dict(),
+        )
+
+    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    res = await get_keys(
+        "http://fail.tld", access_key="asd", secret_key="qwe", uid="foo"
+    )
+    assert len(res) == 1
+    assert res[0].user == "foo"
+    assert res[0].access_key == "asdasd"
+    assert res[0].secret_key == "qweqwe"
+
+
+@pytest.mark.anyio
+async def test_delete_user_key(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/user?key"
+        assert method == "DELETE"
+        assert params is not None
+        assert "uid" in params and params["uid"] == "foo"
+        assert "access-key" in params and params["access-key"] == "asdasd"
+        return httpx.Response(status_code=200)
+
+    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    await delete_key(
+        "http://fail.tld",
+        access_key="asd",
+        secret_key="qwe",
+        uid="foo",
+        user_access_key="asdasd",
+    )
+
+
+@pytest.mark.anyio
+async def test_quota_update(mocker: MockerFixture) -> None:
+    async def _mock_do_request(
+        *,
+        url: str,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        method: str,
+        params: Dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        assert url == "http://fail.tld"
+        assert access_key == "asd"
+        assert secret_key == "qwe"
+        assert endpoint == "/admin/user?quota"
+        assert method == "PUT"
+        assert params is not None
+        assert "uid" in params and params["uid"] == "foo"
+        assert "quota-type" in params and params["quota-type"] == "user"
+        assert "max-objects" in params and params["max-objects"] == 1337
+        assert "enabled" in params and params["enabled"] == True
+        return httpx.Response(status_code=200)
+
+    mocker.patch("backend.admin_ops.users._do_request", _mock_do_request)
+    await quota_update(
+        "http://fail.tld",
+        access_key="asd",
+        secret_key="qwe",
+        uid="foo",
+        quota=UserQuotaOpParams(
+            quota_type="user",
+            max_objects=1337,
+            enabled=True,
+        ),
+    )

--- a/src/backend/tests/admin_ops/test_users.py
+++ b/src/backend/tests/admin_ops/test_users.py
@@ -21,7 +21,6 @@ import pytest
 from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
 
-from backend.admin_ops.errors import AdminOpsError
 from backend.admin_ops.types import (
     UserInfo,
     UserKeyOpParams,
@@ -41,6 +40,7 @@ from backend.admin_ops.users import (
     quota_update,
     update,
 )
+from backend.s3gw.errors import S3GWError
 
 res_user_info_json = {
     "tenant": "",
@@ -103,7 +103,7 @@ async def test_get_user_info_failure(httpx_mock: HTTPXMock) -> None:
         await get_user_info(
             url="http://foo.bar:123", access_key="asd", secret_key="qwe"
         )
-    except AdminOpsError:
+    except S3GWError:
         raised = True
 
     assert raised

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-cov
 pytest-mock
 pyright
 moto[server,s3]
+pytest-httpx

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -9,3 +9,7 @@ types-aiobotocore-s3==2.5.0.post1
 
 # already a dependency of fastapi, but we are now explicitly using it.
 anyio==3.6.2
+
+# httpx is easier than aiohttp for what we want, so we'll bite the bullet of
+# an additional dependency.
+httpx==0.24.0


### PR DESCRIPTION
This patch set adds support for admin ops, but does not add APIs for them.

That shall come in a follow-up patch set.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>