### PR TITLE
.github: add backend codecov coverage report

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,3 +112,8 @@ jobs:
       - name: Run tests
         working-directory: src
         run: tox -e py310
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Adds codecov action to upload a coverage report.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>