### PR TITLE
add Makefile containing frequent development tasks & UI/Backend + UI/Frontend Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ build-ui-fronted:
 image-build-ui-fronted:
 	docker build -t s3gw-frontend:latest -f src/frontend/Dockerfile src/frontend
 
+image-build-ui:
+	docker build -t s3gw-ui:latest -f src/Dockerfile src
+
 ########################################################################
 # Run UI components
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+# Copyright © 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################################################################
+# Setup UI components
+
+setup-ui-backend:
+	cd src \
+	&& python3 -m venv venv \
+	&& source venv/bin/activate \
+	&& pip install -r requirements.txt -r requirements-dev.txt
+
+########################################################################
+# Build UI components
+
+build-ui-fronted:
+	cd src/frontend && npm ci && npx ng build
+
+########################################################################
+# Build UI Image
+
+#Kept for convenience until the new backend architecture is not ready.
+#This will be likely removed in the future.
+image-build-ui-fronted:
+	docker build -t s3gw-frontend:latest -f src/frontend/Dockerfile src/frontend
+
+########################################################################
+# Run UI components
+
+run-ui-backend:
+	cd src \
+	&& python3 -m venv venv \
+	&& source venv/bin/activate \
+	&& S3GW_DEBUG=1 python3 ./s3gw_ui_backend.py
+
+########################################################################
+# Lint UI components
+
+lint-ui-fronted:
+	cd src/frontend && npm run lint
+
+lint-ui-backend:
+	cd src && tox -e lint
+
+########################################################################
+# Check UI components
+
+check-ui-backend:
+	cd src && tox -e types
+
+########################################################################
+# Test UI components
+
+test-ui-fronted:
+	cd src/frontend && npm run test:ci
+
+test-ui-backend:
+	cd src && tox -e py310

--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ It is a combination of two distinct components:
 
 Both the frontend and the backend have their specific `README.md` files, which
 should be consulted for further information.
+
+## Quick build and run reference
+
+### Setup the environment for the UI-Backend
+
+```shell
+make setup-ui-backend
+```
+
+### Build the UI-Frontend
+
+```shell
+make build-ui-fronted
+```
+
+### Run the UI-Backend
+
+```shell
+make run-ui-backend
+```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ make build-ui-fronted
 ```shell
 make run-ui-backend
 ```
+
+### Build the UI Docker Image
+
+```shell
+make image-build-ui
+```

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:lts-alpine as ui-frontend-builder
+
+COPY frontend /srv/frontend
+WORKDIR /srv/frontend
+RUN npm ci \
+ && npm run build:prod
+
+FROM python:alpine3.18 as s3gw-ui
+LABEL Name=s3gw-ui
+
+COPY --from=ui-frontend-builder /srv/frontend/dist/s3gw-ui /srv/frontend/dist/s3gw-ui
+COPY backend /srv/backend
+COPY requirements.txt /srv
+COPY s3gw_ui_backend.py /srv
+WORKDIR /srv
+RUN pip install --no-cache-dir -r requirements.txt
+STOPSIGNAL SIGINT
+EXPOSE 8080
+ENTRYPOINT [ "python", "./s3gw_ui_backend.py" ]


### PR DESCRIPTION
# Describe your changes

1) commit:

Explorative PR to retrieve a feedback if we like a Makefile based approach to invoke common tasks.
I like the makefile approach mainly because it brings the auto-completion feature out of the box.

Added Makefile containing frequent and common development tasks:

 - setup-ui-backend
 - build-ui-fronted
 - image-build-ui-fronted
 - run-ui-backend
 - lint-ui-fronted
 - test-ui-fronted

2) commit:

Added Dockerfile to build the image for the new UI architecture

updated Makefile with:

 - image-build-ui

## Issue ticket number and link

Fixes: https://github.com/aquarist-labs/s3gw/issues/592

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
