### PR TITLE
UI: Do not close datatable column menu on inside clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent the restoring of the deleted object version (gh#aquarist-labs/s3gw#583).
 - Creating an enabled lifecycle rule is not working (gh#aquarist-labs/s3gw#587).
 - Disable download button for deleted objects (gh#aquarist-labs/s3gw#595).
+- Do not close datatable column menu on inside clicks (gh#aquarist-labs/s3gw#599).
 
 ## [0.17.0]
 

--- a/src/frontend/src/app/shared/components/datatable/datatable.component.html
+++ b/src/frontend/src/app/shared/components/datatable/datatable.component.html
@@ -5,7 +5,8 @@
                   select="s3gw-datatable-actions">
       </ng-content>
       <div class="flex-fill"></div>
-      <div ngbDropdown>
+      <div ngbDropdown
+           autoClose="outside">
         <button class="btn btn-simple"
                 ngbDropdownToggle
                 ngbTooltip="{{ 'Show/Hide columns' | transloco }}">


### PR DESCRIPTION
Before:
![Peek 2023-06-27 12-12_before](https://github.com/aquarist-labs/s3gw-ui/assets/1897962/0e2c6666-fc65-4329-8208-acccce0326f7)

After:
![Peek 2023-06-27 12-13_after](https://github.com/aquarist-labs/s3gw-ui/assets/1897962/692b8707-d1dc-4ca7-8ef1-333e10f16b7a)

Fixes: https://github.com/aquarist-labs/s3gw/issues/599

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
