### PR TITLE
add a set of admin-user-api endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ lint-ui-backend:
 	cd src && tox -e lint
 
 ########################################################################
+# Format Code
+
+format-ui-backend:
+	cd src && isort backend && black backend
+
+########################################################################
 # Check UI components
 
 check-ui-backend:

--- a/src/backend/admin_ops/types.py
+++ b/src/backend/admin_ops/types.py
@@ -94,7 +94,7 @@ class UserOpParams(ParamsModel):
 
 class UserKeyOpParams(ParamsModel):
     uid: str
-    key_type: Optional[Literal["s3"]] = Field(default=None)
+    key_type: Optional[str] = Field(default="s3")
     access_key: Optional[str] = Field(default=None)
     secret_key: Optional[str] = Field(default=None)
     generate_key: Optional[bool] = Field(default=None)


### PR DESCRIPTION
# Describe your changes

1. add format-ui-backend task to Makefile
2. add set of user related admin endpoints
    
    Added endpoints:
    
    - api/admin/userIsAuthAdmin
    - api/admin/userListUserIDs
    - api/admin/userCreateKey
    - api/admin/userGetAllKeys
    - api/admin/userDeleteKey
    - api/admin/userUpdateQuota

## Issue ticket number and link

Refers to: https://github.com/aquarist-labs/s3gw/issues/606
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR
