### PR TITLE
Table header breaks on zoom-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0]
+
+### Fixed
+
+- Table header breaks on zoom-in (gh#aquarist-labs/s3gw#618).
+
 ## [0.18.0]
 
 ### Added

--- a/src/frontend/src/app/shared/components/datatable/datatable.component.ts
+++ b/src/frontend/src/app/shared/components/datatable/datatable.component.ts
@@ -335,7 +335,7 @@ export class DatatableComponent implements Datatable, OnInit {
   }
 
   getHeaderClasses(column: DatatableColumn): string {
-    let css = column.css || '';
+    let css = column.cssHeader || '';
     if (column.sortable !== true) {
       return css;
     }

--- a/src/frontend/src/app/shared/models/datatable-column.type.ts
+++ b/src/frontend/src/app/shared/models/datatable-column.type.ts
@@ -64,6 +64,7 @@ export enum DatatableCellTemplateName {
 export type DatatableColumn = {
   width?: number | string;
   css?: string;
+  cssHeader?: string;
   name: string;
   prop: string;
   compareProp?: string;


### PR DESCRIPTION
The `css` property of the `DatatableColumn` type was meant for the column content. The issue has been fixed by introducing the new `cssHeader` property which can be used to customize the column header.

Fixes: https://github.com/aquarist-labs/s3gw/issues/618

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
