### PR TITLE
backend: obtain 's3gw' service address via env variable

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,18 +2,27 @@ FROM node:lts-alpine as ui-frontend-builder
 
 COPY frontend /srv/frontend
 WORKDIR /srv/frontend
-RUN npm ci \
- && npm run build:prod
+RUN npm ci && npm run build:prod
 
 FROM python:alpine3.18 as s3gw-ui
+ARG QUAY_EXPIRATION=Never
+
 LABEL Name=s3gw-ui
+LABEL quay.expires-after=${QUAY_EXPIRATION}
 
 COPY --from=ui-frontend-builder /srv/frontend/dist/s3gw-ui /srv/frontend/dist/s3gw-ui
 COPY backend /srv/backend
 COPY requirements.txt /srv
 COPY s3gw_ui_backend.py /srv
+
 WORKDIR /srv
 RUN pip install --no-cache-dir -r requirements.txt
+RUN rm -f requirements.txt
+
 STOPSIGNAL SIGINT
 EXPOSE 8080
-ENTRYPOINT [ "python", "./s3gw_ui_backend.py" ]
+
+ENTRYPOINT [ \
+    "uvicorn", "--factory", "s3gw_ui_backend:app_factory", \
+    "--host", "0.0.0.0", "--port", "8080" \
+    ]

--- a/src/backend/api/admin.py
+++ b/src/backend/api/admin.py
@@ -22,7 +22,7 @@ import backend.admin_ops.types as admin_ops_types
 import backend.admin_ops.users as admin_ops_users
 from backend.api import S3GWClient, s3gw_client, s3gw_client_responses
 
-router = APIRouter(prefix="/admin")
+router = APIRouter(prefix="/admin", tags=["admin ops"])
 
 S3GWClientDep = Annotated[S3GWClient, Depends(s3gw_client)]
 

--- a/src/backend/api/buckets.py
+++ b/src/backend/api/buckets.py
@@ -39,7 +39,7 @@ from backend.api.types import (
     TagSet,
 )
 
-router = APIRouter(prefix="/buckets")
+router = APIRouter(prefix="/buckets", tags=["bucket"])
 
 S3GWClientDep = Annotated[S3GWClient, Depends(s3gw_client)]
 

--- a/src/backend/api/config.py
+++ b/src/backend/api/config.py
@@ -1,0 +1,35 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import Request
+from fastapi.routing import APIRouter
+from pydantic import BaseModel
+
+from backend.config import Config
+
+
+class ConfigResponse(BaseModel):
+    endpoint: str
+
+
+router = APIRouter(prefix="/config", tags=["config"])
+
+
+@router.get(
+    "/",
+    response_model=ConfigResponse,
+)
+async def get_config(req: Request) -> ConfigResponse:
+    cfg: Config = req.app.state.config
+    return ConfigResponse(endpoint=cfg.s3gw_addr)

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,0 +1,49 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+from fastapi.logger import logger
+
+
+def get_s3gw_address() -> str:
+    """Obtain s3gw service address from environment, and validate format."""
+
+    url = os.environ.get("S3GW_SERVICE_URL")
+    if url is None:
+        logger.error("S3GW_SERVICE_URL env variable not set!")
+        raise Exception()
+    m = re.fullmatch(r"https?://[\w.-]+(?:\.[\w]+)?(?::\d+)?/?", url)
+    if m is None:
+        logger.error(f"Malformed s3gw URL: {url}")
+        raise Exception()
+
+    return url
+
+
+class Config:
+    """Keeps config relevant for the backend's operation."""
+
+    # Address for the s3gw instance we're servicing.
+    _s3gw_addr: str
+
+    def __init__(self) -> None:
+        self._s3gw_addr = get_s3gw_address()
+        logger.info(f"Servicing s3gw at {self._s3gw_addr}")
+
+    @property
+    def s3gw_addr(self) -> str:
+        """Obtain the address for the s3gw instance we are servicing."""
+        return self._s3gw_addr

--- a/src/backend/tests/unit/api/test_api.py
+++ b/src/backend/tests/unit/api/test_api.py
@@ -20,30 +20,6 @@ from backend.api import S3GWClient, decode_client_error, s3gw_client
 
 
 @pytest.mark.anyio
-async def test_s3gw_conn_malformed_url() -> None:
-    creds = "foo:bar"
-    bad_urls = [
-        "something://foo.bar:123",
-        "http:/foo.bar:123",
-        "http//foo.bar:123",
-        "httpp://foo.bar:123",
-        "https://foo+bar:123",
-        "https://foo.bar:123a",
-    ]
-
-    for url in bad_urls:
-        error_found = False
-        try:
-            await s3gw_client(url, creds)
-        except HTTPException as e:
-            assert e.status_code == status.HTTP_400_BAD_REQUEST
-            error_found = True
-        if not error_found:
-            print(f"test failed at '{url}'")
-        assert error_found
-
-
-@pytest.mark.anyio
 async def test_s3gw_conn_malformed_creds() -> None:
     url = "https://foo.bar:123"
     bad_creds = [

--- a/src/backend/tests/unit/api/test_api_config.py
+++ b/src/backend/tests/unit/api/test_api_config.py
@@ -1,0 +1,41 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastapi import Request
+from pytest_mock import MockerFixture
+
+from backend.api import config as api_config
+from backend.config import Config
+
+
+@pytest.mark.anyio
+async def test_get_config(mocker: MockerFixture) -> None:
+    class MockState:
+        config: Config
+
+    class MockApp:
+        state: MockState
+
+    p = mocker.patch("backend.config.get_s3gw_address")
+    p.return_value = "http://foo.bar:123"
+
+    test_config = Config()
+
+    req = Request({"type": "http", "app": MockApp()})
+    req.app.state = MockState()
+    req.app.state.config = test_config
+    res = await api_config.get_config(req)
+    assert isinstance(res, api_config.ConfigResponse)
+    assert res.endpoint == "http://foo.bar:123"

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -1,0 +1,73 @@
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from backend.config import Config, get_s3gw_address
+
+
+def test_s3gw_malformed_address() -> None:
+    bad_urls = [
+        "something://foo.bar:123",
+        "http:/foo.bar:123",
+        "http//foo.bar:123",
+        "httpp://foo.bar:123",
+        "https://foo+bar:123",
+        "https://foo.bar:123a",
+    ]
+
+    for url in bad_urls:
+        os.environ["S3GW_SERVICE_URL"] = url
+
+        error_found = False
+        try:
+            get_s3gw_address()
+        except Exception:
+            error_found = True
+
+        assert error_found
+
+
+def test_s3gw_good_address() -> None:
+    addr = "http://foo.bar:123"
+
+    error_found = False
+    os.environ["S3GW_SERVICE_URL"] = addr
+    try:
+        ret = get_s3gw_address()
+        assert ret == addr
+    except Exception:
+        error_found = True
+
+    assert not error_found
+
+
+def test_config() -> None:
+    bad_addr = "something:foo.bar:123"
+    os.environ["S3GW_SERVICE_URL"] = bad_addr
+    error_found = False
+    try:
+        Config()
+    except Exception:
+        error_found = True
+
+    assert error_found
+
+    good_addr = "http://foo.bar:123"
+    os.environ["S3GW_SERVICE_URL"] = good_addr
+    try:
+        cfg = Config()
+        assert cfg.s3gw_addr == good_addr
+    except Exception:
+        assert False

--- a/src/frontend/src/app/shared/services/api/s3gw-api.service.ts
+++ b/src/frontend/src/app/shared/services/api/s3gw-api.service.ts
@@ -85,7 +85,6 @@ export class S3gwApiService {
   private buildHeaders(credentials: Credentials): Record<string, any> {
     return {
       /* eslint-disable @typescript-eslint/naming-convention */
-      'S3GW-Endpoint': this.config.url,
       'S3GW-Credentials': `${credentials.accessKey}:${credentials.secretKey}`
       /* eslint-enable @typescript-eslint/naming-convention */
     };

--- a/src/frontend/src/app/shared/services/s3gw-config.service.spec.ts
+++ b/src/frontend/src/app/shared/services/s3gw-config.service.spec.ts
@@ -20,10 +20,4 @@ describe('S3gwConfigService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
-
-  it('should load config', () => {
-    service.load().subscribe();
-    const req = httpTesting.expectOne('assets/rgw_service.config.json');
-    expect(req.request.method).toBe('GET');
-  });
 });

--- a/src/frontend/src/app/shared/services/s3gw-config.service.ts
+++ b/src/frontend/src/app/shared/services/s3gw-config.service.ts
@@ -1,8 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import * as _ from 'lodash';
-import { EMPTY, Observable } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
 
 export type S3gwConfig = {
   apiUrl: string;
@@ -29,32 +27,10 @@ export class S3gwConfigService {
   public load(): Observable<S3gwConfig> {
     // Try to load the configuration file containing the information
     // to access the RGW.
-    return this.http
-      .get<Partial<S3gwConfig>>('assets/rgw_service.config.json', {
-        headers: {
-          /* eslint-disable @typescript-eslint/naming-convention */
-          'Cache-Control': 'no-cache',
-          Pragma: 'no-cache'
-          /* eslint-enable @typescript-eslint/naming-convention */
-        }
-      })
-      .pipe(
-        catchError((err) => {
-          err.preventDefault?.();
-          return EMPTY;
-        }),
-        map((config: Partial<S3gwConfig>) => {
-          // Make sure the environment variables have been replaced by real URLs.
-          if (config?.apiUrl === '$S3GW_UI_API_URL') {
-            config.apiUrl = 'api/'; // Reset to default value.
-          }
-          if (config?.url === '$RGW_SERVICE_URL') {
-            config.url = ''; // Reset to default value.
-          }
-          // eslint-disable-next-line no-underscore-dangle
-          return _.merge(this._config, config);
-        })
-      );
+
+    // eslint-disable-next-line no-underscore-dangle
+    this._config.apiUrl = 'api/';
+    return of(this.config);
   }
 
   /**
@@ -62,6 +38,6 @@ export class S3gwConfigService {
    */
   public isValid(): boolean {
     // At the moment it is enough to check if the URL is empty.
-    return this.config.apiUrl !== '' && this.config.url !== '';
+    return this.config.apiUrl !== '';
   }
 }

--- a/src/frontend/src/assets/rgw_service.config.json.sample
+++ b/src/frontend/src/assets/rgw_service.config.json.sample
@@ -1,4 +1,0 @@
-{
-  "apiUrl": "$S3GW_UI_API_URL",
-  "url": "$RGW_SERVICE_URL"
-}

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -55,6 +55,10 @@ def s3gw_factory(
             "name": "bucket",
             "description": "Bucket related operations",
         },
+        {
+            "name": "admin ops",
+            "description": "Admin operations, non-S3 compliant",
+        },
     ]
 
     s3gw_app = FastAPI(docs_url=None)

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -23,7 +23,7 @@ from fastapi import FastAPI
 from fastapi.logger import logger
 from fastapi.staticfiles import StaticFiles
 
-from backend.api import admin, auth, buckets, objects
+from backend.api import admin, auth, buckets, config, objects
 from backend.config import Config
 from backend.logging import setup_logging
 
@@ -59,6 +59,10 @@ def s3gw_factory(
             "name": "admin ops",
             "description": "Admin operations, non-S3 compliant",
         },
+        {
+            "name": "config",
+            "description": "Backend config operations",
+        },
     ]
 
     s3gw_app = FastAPI(docs_url=None)
@@ -81,6 +85,7 @@ def s3gw_factory(
     s3gw_api.include_router(auth.router)
     s3gw_api.include_router(buckets.router)
     s3gw_api.include_router(objects.router)
+    s3gw_api.include_router(config.router)
 
     s3gw_app.mount("/api", s3gw_api, name="api")
     if static_dir is not None:

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import sys
 from typing import Awaitable, Callable
 
 import uvicorn
@@ -23,12 +24,18 @@ from fastapi.logger import logger
 from fastapi.staticfiles import StaticFiles
 
 from backend.api import admin, auth, buckets, objects
+from backend.config import Config
 from backend.logging import setup_logging
 
 
 async def s3gw_startup(s3gw_app: FastAPI, s3gw_api: FastAPI) -> None:
     setup_logging()
     logger.info("Starting s3gw-ui backend")
+    try:
+        s3gw_api.state.config = Config()
+    except Exception:
+        logger.error("unable to init config -- exit!")
+        sys.exit(1)
 
 
 async def s3gw_shutdown(s3gw_app: FastAPI, s3gw_api: FastAPI) -> None:


### PR DESCRIPTION
~**NOTE BEFORE:** this patch set requires #241 to be merged first. Not all patches will be part of this patch set final history.~  (#241 has been merged, we're good to go)

Instead of relying on the frontend to provide us with the address for the `s3gw` service, rely instead on an environment variable.

This means that the new container requires the `S3GW_SERVICE_URL` environment variable to be provided. E.g.,

`podman run -it -p 31337:8080 -e S3GW_SERVICE_URL=http://172.20.20.5:7480 localhost/s3gw-ui:uvicorn`

for an `s3gw` running on `172.20.20.5` port `7480`.


Signed-off-by: Joao Eduardo Luis \<joao@suse.com>