### PR TITLE
ci: Add quay expiry labels

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -7,6 +7,9 @@ RUN npm ci \
 
 FROM node:lts-alpine
 
+ARG QUAY_EXPIRATION=Never
+LABEL quay.expires-after=${QUAY_EXPIRATION}
+
 COPY --from=builder /srv/app/dist/s3gw-ui /app
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 


### PR DESCRIPTION
Add labels to Dockerfile regulating image expiry in quay.io. This is a prerequisite for nightly builds of the UI container as the nightly builds need to be expired.

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
