### PR TITLE
UI: Edit bucket in UI allows user to switch retention mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0]
+
+### Fixed
+
+- Prevent switching bucket retention mode from `Compliance` to `Governance` (gh#aquarist-labs/s3gw#553).
+
 ## [0.20.0]
 
 ### Changed

--- a/src/frontend/src/app/pages/user/bucket/bucket-form-page/bucket-form-page.component.ts
+++ b/src/frontend/src/app/pages/user/bucket/bucket-form-page/bucket-form-page.component.ts
@@ -76,6 +76,11 @@ export class BucketFormPageComponent implements OnInit, IsDirty {
           if (this.editing && bucket.VersioningEnabled) {
             this.form.getControl('VersioningEnabled')?.disable();
           }
+          if (this.editing && bucket.RetentionEnabled && bucket.RetentionMode === 'COMPLIANCE') {
+            this.form.getControl('RetentionMode')?.disable();
+            this.form.getControl('RetentionValidity')?.disable();
+            this.form.getControl('RetentionUnit')?.disable();
+          }
         },
         error: (err) => {
           this.pageStatus = PageStatus.loadingError;


### PR DESCRIPTION
The following rules apply to retention mode:

Allowed: `Governance` -> `Compliance`
Not allowed: `Compliance` -> `Governance`

If the retention mode is `Compliance`, then the `Validity` and `Unit` form fields are disabled as well.

Fixes: https://github.com/aquarist-labs/s3gw/issues/553

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
