### PR TITLE
Inconsistent restore behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix several theming issues (gh#aquarist-labs/s3gw#728).
+- Disable `Restore` and `Download` action buttons in object version
+  page correctly (gh#aquarist-labs/s3gw#747).
 
 ## [0.21.0]
 

--- a/src/frontend/src/app/pages/user/object/object-version-datatable-page/object-version-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/user/object/object-version-datatable-page/object-version-datatable-page.component.ts
@@ -71,7 +71,13 @@ export class ObjectVersionDatatablePageComponent implements OnInit {
         text: TEXT('Download'),
         icon: this.icons.download,
         enabledConstraints: {
-          minSelected: 1
+          minSelected: 1,
+          constraint: [
+            {
+              operator: 'falsy',
+              arg0: { prop: 'IsDeleted' }
+            }
+          ]
         },
         callback: (event: Event, action: DatatableAction, table: Datatable) =>
           this.doDownload(table.selected[0] as S3ObjectVersion)
@@ -81,7 +87,17 @@ export class ObjectVersionDatatablePageComponent implements OnInit {
         text: TEXT('Restore'),
         icon: this.icons.restore,
         enabledConstraints: {
-          minSelected: 1
+          minSelected: 1,
+          constraint: [
+            {
+              operator: 'falsy',
+              arg0: { prop: 'IsDeleted' }
+            },
+            {
+              operator: 'falsy',
+              arg0: { prop: 'IsLatest' }
+            }
+          ]
         },
         callback: (event: Event, action: DatatableAction, table: Datatable) =>
           this.doRestore(table.selected[0] as S3ObjectVersion)


### PR DESCRIPTION
The datatable `Restore` action button does not behave the same way as the row action menu. In this case the `Restore` button is not disabled when the selected item is a delete marker or is the latest version.

Additionally the `Download` table action button will be disabled when the selected version is a delete marker.

Fixes: https://github.com/aquarist-labs/s3gw/issues/747
