### PR TITLE
Dockerfile: pin base image to python3.11

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,7 +4,7 @@ COPY frontend /srv/frontend
 WORKDIR /srv/frontend
 RUN npm ci && npm run build:prod
 
-FROM python:alpine3.18 as s3gw-ui
+FROM python:3.11-alpine3.18 as s3gw-ui
 ARG QUAY_EXPIRATION=Never
 
 LABEL Name=s3gw-ui

--- a/src/backend/api/buckets.py
+++ b/src/backend/api/buckets.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import asyncio
-from typing import Annotated, List
+from typing import Annotated, Any, List
 
 import pydash
 from fastapi import Depends, HTTPException, Response, status
@@ -333,8 +333,12 @@ async def get_bucket_attributes(
         get_bucket_object_lock_configuration(conn=conn, bucket=bucket),
         get_bucket_tagging(conn=conn, bucket=bucket),
     ]
-    reqs_res = await asyncio.gather(*reqs, return_exceptions=True)
+    reqs_res: list[Any] = await asyncio.gather(*reqs, return_exceptions=True)
     assert len(reqs_res) == 3
+
+    # gbv_res: bool | HTTPException = reqs_res[0]
+    # gbl_res: BucketObjectLock | HTTPException = reqs_res[1]
+    # gbt_res: List[Tag] | HTTPException = reqs_res[2]
 
     gbv_res, gbl_res, gbt_res = reqs_res
 

--- a/src/backend/api/objects.py
+++ b/src/backend/api/objects.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import asyncio
 from collections import deque
-from typing import Annotated, Deque, List, Optional
+from typing import Annotated, Any, Deque, List, Optional
 
 from fastapi import (
     Depends,
@@ -513,7 +513,7 @@ async def get_object_attributes(
         get_object(conn=conn, bucket=bucket, params=params),
         get_object_tagging(conn=conn, bucket=bucket, params=params),
     ]
-    reqs_res = await asyncio.gather(*reqs, return_exceptions=True)
+    reqs_res: list[Any] = await asyncio.gather(*reqs, return_exceptions=True)
     assert len(reqs_res) == 2
 
     go_res, got_res = reqs_res

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -39,7 +39,7 @@ deps =
     {[base-dev]deps}
 commands =
     pyright \
-      --pythonversion 3.10 \
+      --pythonversion 3.11 \
       --pythonplatform Linux \
       s3gw_ui_backend.py backend/
 


### PR DESCRIPTION
Otherwise we were ending up on the bleeding edge of alpine3.18, which at this moment means python3.12, which in turn doesn't play nice yet with a lot of libraries. And we don't need to be on the bleeding edge, so lets just pin a version.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>