### PR TITLE
Makefile: make running backend more resilient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.PHONY: check-ui-backend-env
+
 ########################################################################
 # Testing cluster
 
@@ -51,9 +53,8 @@ image-build-ui:
 ########################################################################
 # Run UI components
 
-run-ui-backend:
+run-ui-backend: check-ui-backend-env setup-ui-backend build-ui-frontend
 	cd src \
-	&& python3 -m venv venv \
 	&& source venv/bin/activate \
 	&& S3GW_DEBUG=1 python3 ./s3gw_ui_backend.py
 
@@ -95,3 +96,12 @@ test-ui-backend:
 
 test-ui-backend-with-s3gw:
 	@./test-env/run-tests.sh
+
+# Check whether we have a valid S3GW_SERVICE_URL environment variable
+#
+check-ui-backend-env:
+ifndef S3GW_SERVICE_URL
+	$(error S3GW_SERVICE_URL must be set.)
+endif
+
+

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ setup-ui-backend:
 ########################################################################
 # Build UI components
 
-build-ui-fronted:
+build-ui-frontend:
 	cd src/frontend && npm ci && npx ng build
 
 ########################################################################
@@ -42,7 +42,7 @@ build-ui-fronted:
 
 #Kept for convenience until the new backend architecture is not ready.
 #This will be likely removed in the future.
-image-build-ui-fronted:
+image-build-ui-frontend:
 	docker build -t s3gw-frontend:latest -f src/frontend/Dockerfile src/frontend
 
 image-build-ui:


### PR DESCRIPTION
Instead of blindly running the backend, check for a few prerequisites first, like building the frontend, for an actual venv, etc.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>