### PR TITLE
longhorn integration: subpath support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,6 +100,17 @@ jobs:
       - name: Checkout s3gw UI
         uses: actions/checkout@v3
 
+      - name: Set up node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+          cache-dependency-path: src/frontend/package-lock.json
+
+      - name: Install Dependencies
+        working-directory: src/frontend
+        run: npm ci
+
       - name: Install Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -108,6 +119,10 @@ jobs:
 
       - name: Install tox
         run: pip install tox
+
+      - name: Build Frontend
+        working-directory: src/frontend
+        run: npx ng build
 
       - name: Run unit tests
         working-directory: src

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ tmp
 proxy.conf.json
 
 .pre-commit-venv
-
 /venv
+.venv

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,6 +22,8 @@ RUN rm -f requirements.txt
 STOPSIGNAL SIGINT
 EXPOSE 8080
 
+ENV S3GW_UI_LOCATION "/s3store"
+
 ENTRYPOINT [ \
     "uvicorn", "--factory", "s3gw_ui_backend:app_factory", \
     "--host", "0.0.0.0", "--port", "8080" \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:lts-alpine as ui-frontend-builder
+FROM registry.suse.com/bci/nodejs:18 as ui-frontend-builder
 
 COPY frontend /srv/frontend
 WORKDIR /srv/frontend
 RUN npm ci && npm run build:prod
 
-FROM python:3.11-alpine3.18 as s3gw-ui
+FROM registry.suse.com/bci/python:3.11 as s3gw-ui
 ARG QUAY_EXPIRATION=Never
 
 LABEL Name=s3gw-ui
@@ -16,13 +16,13 @@ COPY requirements.txt /srv
 COPY s3gw_ui_backend.py /srv
 
 WORKDIR /srv
-RUN pip install --no-cache-dir -r requirements.txt
-RUN rm -f requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+ && rm -f requirements.txt
 
 STOPSIGNAL SIGINT
 EXPOSE 8080
 
-ENV S3GW_UI_LOCATION "/s3store"
+ENV S3GW_UI_PATH "/"
 
 ENTRYPOINT [ \
     "uvicorn", "--factory", "s3gw_ui_backend:app_factory", \

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -33,20 +33,25 @@ def get_s3gw_address() -> str:
     return url
 
 
-def get_ui_location() -> str:
-    """Obtain the location path under which the UI should be served, e.g. /ui"""
-    loc = os.environ.get("S3GW_UI_LOCATION")
-    if loc is None:
+def get_ui_path() -> str:
+    """Obtain the path under which the UI should be served, e.g. /ui"""
+    path = os.environ.get("S3GW_UI_PATH")
+    if path is None:
         return "/"
-    m = re.fullmatch(r"/?[\w.-/]+(?:[\w]+)/?", loc)
-    if m is None:
-        logger.error(f"Malformed path for UI location: {loc}")
-        raise Exception("Malformed UI location")
-    return loc if loc.startswith("/") else f"/{loc}"
+    match = re.fullmatch(r"/?[\w.-/]+(?:[\w]+)/?", path)
+    if match is None:
+        logger.error(f"Malformed path for UI: {path}")
+        raise Exception("Malformed UI path")
+    return path if path.startswith("/") else f"/{path}"
 
 
-def get_api_location(ui_location: str) -> str:
-    return f"{ui_location.rstrip('/')}/api"
+def get_api_path(ui_path: str) -> str:
+    """
+    Obtain the path under which the API for the UI should be served from the
+    path of the UI itself. E.g. when the UI path is `/ui`, this will be
+    `/ui/api`
+    """
+    return f"{ui_path.rstrip('/')}/api"
 
 
 class Config:
@@ -55,13 +60,13 @@ class Config:
     # Address for the s3gw instance we're servicing.
     _s3gw_addr: str
 
-    _ui_location: str
-    _api_location: str
+    _ui_path: str
+    _api_path: str
 
     def __init__(self) -> None:
         self._s3gw_addr = get_s3gw_address()
-        self._ui_location = get_ui_location()
-        self._api_location = get_api_location(self._ui_location)
+        self._ui_path = get_ui_path()
+        self._api_path = get_api_path(self._ui_path)
         logger.info(f"Servicing s3gw at {self._s3gw_addr}")
 
     @property
@@ -70,11 +75,11 @@ class Config:
         return self._s3gw_addr
 
     @property
-    def ui_location(self) -> str:
-        """Obtain UI location path"""
-        return self._ui_location
+    def ui_path(self) -> str:
+        """Obtain UI path"""
+        return self._ui_path
 
     @property
-    def api_location(self) -> str:
-        """Obtain API location path"""
-        return self._api_location
+    def api_path(self) -> str:
+        """Obtain API path"""
+        return self._api_path

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -33,17 +33,48 @@ def get_s3gw_address() -> str:
     return url
 
 
+def get_ui_location() -> str:
+    """Obtain the location path under which the UI should be served, e.g. /ui"""
+    loc = os.environ.get("S3GW_UI_LOCATION")
+    if loc is None:
+        return "/"
+    m = re.fullmatch(r"/?[\w.-/]+(?:[\w]+)/?", loc)
+    if m is None:
+        logger.error(f"Malformed path for UI location: {loc}")
+        raise Exception("Malformed UI location")
+    return loc if loc.startswith("/") else f"/{loc}"
+
+
+def get_api_location(ui_location: str) -> str:
+    return f"{ui_location.rstrip('/')}/api"
+
+
 class Config:
     """Keeps config relevant for the backend's operation."""
 
     # Address for the s3gw instance we're servicing.
     _s3gw_addr: str
 
+    _ui_location: str
+    _api_location: str
+
     def __init__(self) -> None:
         self._s3gw_addr = get_s3gw_address()
+        self._ui_location = get_ui_location()
+        self._api_location = get_api_location(self._ui_location)
         logger.info(f"Servicing s3gw at {self._s3gw_addr}")
 
     @property
     def s3gw_addr(self) -> str:
         """Obtain the address for the s3gw instance we are servicing."""
         return self._s3gw_addr
+
+    @property
+    def ui_location(self) -> str:
+        """Obtain UI location path"""
+        return self._ui_location
+
+    @property
+    def api_location(self) -> str:
+        """Obtain API location path"""
+        return self._api_location

--- a/src/backend/tests/unit/test_app.py
+++ b/src/backend/tests/unit/test_app.py
@@ -18,7 +18,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from s3gw_ui_backend import NoCacheStaticFiles
+from s3gw_ui_backend import NoCacheStaticFiles, app_factory
 
 
 @pytest.fixture
@@ -67,3 +67,12 @@ def test_static_files_2(test_data: PosixPath) -> None:
     assert "cache-control" not in resp.headers
     assert "expires" not in resp.headers
     assert "pragma" not in resp.headers
+
+
+def test_api() -> None:
+    app = app_factory()
+    client = TestClient(app)
+
+    resp = client.get("/api/buckets/")
+    assert resp.status_code == 422
+    assert resp.headers["content-type"] == "application/json"

--- a/src/backend/tests/unit/test_app.py
+++ b/src/backend/tests/unit/test_app.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path, PosixPath
 
 import pytest
@@ -69,10 +70,12 @@ def test_static_files_2(test_data: PosixPath) -> None:
     assert "pragma" not in resp.headers
 
 
-def test_api() -> None:
+def test_config_init() -> None:
+    os.environ["S3GW_SERVICE_URL"] = "http://s3gw.example.com"
+    os.environ["S3GW_UI_LOCATION"] = "/s3gwui"
     app = app_factory()
-    client = TestClient(app)
-
-    resp = client.get("/api/buckets/")
-    assert resp.status_code == 422
-    assert resp.headers["content-type"] == "application/json"
+    with TestClient(app) as client:
+        ui_resp = client.get("/s3gwui")
+        assert ui_resp.status_code == 200
+        api_resp = client.get("/s3gwui/api/buckets/")
+        assert api_resp.status_code == 422

--- a/src/backend/tests/unit/test_app.py
+++ b/src/backend/tests/unit/test_app.py
@@ -72,7 +72,7 @@ def test_static_files_2(test_data: PosixPath) -> None:
 
 def test_config_init() -> None:
     os.environ["S3GW_SERVICE_URL"] = "http://s3gw.example.com"
-    os.environ["S3GW_UI_LOCATION"] = "/s3gwui"
+    os.environ["S3GW_UI_PATH"] = "/s3gwui"
     app = app_factory()
     with TestClient(app) as client:
         ui_resp = client.get("/s3gwui")

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI, Request
 from starlette.datastructures import State
 
 from backend.api import s3gw_endpoint
-from backend.config import Config, get_s3gw_address, get_ui_location
+from backend.config import Config, get_s3gw_address, get_ui_path
 
 
 def test_s3gw_malformed_address() -> None:
@@ -82,52 +82,52 @@ def test_s3gw_endpoint() -> None:
     assert res == addr
 
 
-def test_malformed_ui_app_location() -> None:
-    bad_locations = [
+def test_malformed_ui_path() -> None:
+    bad_paths = [
         "",
         "foo:bar",
     ]
-    for loc in bad_locations:
-        os.environ["S3GW_UI_LOCATION"] = loc
+    for loc in bad_paths:
+        os.environ["S3GW_UI_PATH"] = loc
         with pytest.raises(Exception) as e:
-            get_ui_location()
-        assert str(e.value) == "Malformed UI location"
+            get_ui_path()
+        assert str(e.value) == "Malformed UI path"
 
 
-def test_good_ui_app_location() -> None:
-    loc = "/s3store"
-    os.environ["S3GW_UI_LOCATION"] = loc
+def test_good_ui_path() -> None:
+    path = "/s3store"
+    os.environ["S3GW_UI_PATH"] = path
     try:
         cfg = Config()
-        assert cfg.ui_location == loc
+        assert cfg.ui_path == path
     except Exception as e:
         pytest.fail(str(e))
 
 
-def test_no_ui_app_location() -> None:
-    os.environ.pop("S3GW_UI_LOCATION")
+def test_no_ui_path() -> None:
+    os.environ.pop("S3GW_UI_PATH")
     try:
         cfg = Config()
-        assert cfg.ui_location == "/"
+        assert cfg.ui_path == "/"
     except Exception as e:
         pytest.fail(str(e))
 
 
-def test_good_ui_api_location() -> None:
-    loc = "/s3store"
-    os.environ["S3GW_UI_LOCATION"] = loc
+def test_good_ui_api_path() -> None:
+    path = "/s3store"
+    os.environ["S3GW_UI_PATH"] = path
     try:
         cfg = Config()
-        assert cfg.api_location == "/s3store/api"
+        assert cfg.api_path == "/s3store/api"
     except Exception as e:
         pytest.fail(str(e))
 
 
-def test_api_location_with_trailing_slash() -> None:
-    loc = "/s3store/"
-    os.environ["S3GW_UI_LOCATION"] = loc
+def test_api_path_with_trailing_slash() -> None:
+    path = "/s3store/"
+    os.environ["S3GW_UI_PATH"] = path
     try:
         cfg = Config()
-        assert cfg.api_location == "/s3store/api"
+        assert cfg.api_path == "/s3store/api"
     except Exception as e:
         pytest.fail(str(e))

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -75,7 +75,6 @@ def s3gw_factory(
     startup: s3gwAsyncMethod = s3gw_startup,
     shutdown: s3gwAsyncMethod = s3gw_shutdown,
     static_dir: str | None = None,
-    app_location: str | None = None,
 ) -> FastAPI:
     api_tags_meta = [
         {
@@ -114,11 +113,7 @@ def s3gw_factory(
     s3gw_api.include_router(objects.router)
     s3gw_api.include_router(config.router)
 
-    s3gw_app.mount(
-        f"{app_location}/api" if app_location is not None else "/api",
-        s3gw_api,
-        name="api",
-    )
+    s3gw_app.mount(s3gw_api.state.config.api_location(), s3gw_api, name="api")
 
     if static_dir is not None:
         # Disable caching of `index.html` on purpose so that the browser
@@ -126,7 +121,7 @@ def s3gw_factory(
         # app are not taken into account when the browser is loading the
         # file from the cache.
         s3gw_app.mount(
-            app_location if app_location is not None else "/",
+            s3gw_api.state.config.ui_location(),
             NoCacheStaticFiles(
                 no_cache_files=["/"], directory=static_dir, html=True
             ),
@@ -137,14 +132,10 @@ def s3gw_factory(
 
 
 def app_factory():
-    s3gw_ui_location = os.getenv("S3GW_UI_LOCATION")
-
     static_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "frontend/dist/s3gw-ui/"
     )
-    return s3gw_factory(
-        s3gw_startup, s3gw_shutdown, static_dir, s3gw_ui_location
-    )
+    return s3gw_factory(s3gw_startup, s3gw_shutdown, static_dir)
 
 
 def main():

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -101,7 +101,7 @@ def s3gw_factory(static_dir: str | None = None) -> FastAPI:
     s3gw_api.include_router(objects.router)
     s3gw_api.include_router(config.router)
 
-    s3gw_app.mount(s3gw_api.state.config.api_location, s3gw_api, name="api")
+    s3gw_app.mount(s3gw_api.state.config.api_path, s3gw_api, name="api")
 
     if static_dir is not None:
         # Disable caching of `index.html` on purpose so that the browser
@@ -109,7 +109,7 @@ def s3gw_factory(static_dir: str | None = None) -> FastAPI:
         # app are not taken into account when the browser is loading the
         # file from the cache.
         s3gw_app.mount(
-            s3gw_api.state.config.ui_location,
+            s3gw_api.state.config.ui_path,
             NoCacheStaticFiles(
                 no_cache_files=["/"], directory=static_dir, html=True
             ),

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -115,9 +115,10 @@ def s3gw_factory(
     s3gw_api.include_router(config.router)
 
     s3gw_app.mount(
-            f"{app_location}/api" if app_location is not None else "/api",
-            s3gw_api,
-            name="api")
+        f"{app_location}/api" if app_location is not None else "/api",
+        s3gw_api,
+        name="api",
+    )
 
     if static_dir is not None:
         # Disable caching of `index.html` on purpose so that the browser
@@ -141,10 +142,9 @@ def app_factory():
     static_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "frontend/dist/s3gw-ui/"
     )
-    return s3gw_factory(s3gw_startup,
-                        s3gw_shutdown,
-                        static_dir,
-                        s3gw_ui_location)
+    return s3gw_factory(
+        s3gw_startup, s3gw_shutdown, static_dir, s3gw_ui_location
+    )
 
 
 def main():

--- a/src/s3gw_ui_backend.py
+++ b/src/s3gw_ui_backend.py
@@ -16,7 +16,8 @@
 
 import os
 import sys
-from typing import Any, Awaitable, Callable, List
+from contextlib import asynccontextmanager
+from typing import Any, AsyncGenerator, List
 
 import uvicorn
 from fastapi import FastAPI, Response
@@ -54,28 +55,15 @@ class NoCacheStaticFiles(StaticFiles):
         return resp
 
 
-async def s3gw_startup(s3gw_app: FastAPI, s3gw_api: FastAPI) -> None:
+@asynccontextmanager
+async def lifespan(api: FastAPI) -> AsyncGenerator[None, Any]:
     setup_logging()
     logger.info("Starting s3gw-ui backend")
-    try:
-        s3gw_api.state.config = Config()
-    except Exception:
-        logger.error("unable to init config -- exit!")
-        sys.exit(1)
-
-
-async def s3gw_shutdown(s3gw_app: FastAPI, s3gw_api: FastAPI) -> None:
+    yield
     logger.info("Shutting down s3gw-ui backend")
 
 
-s3gwAsyncMethod = Callable[[FastAPI, FastAPI], Awaitable[None]]
-
-
-def s3gw_factory(
-    startup: s3gwAsyncMethod = s3gw_startup,
-    shutdown: s3gwAsyncMethod = s3gw_shutdown,
-    static_dir: str | None = None,
-) -> FastAPI:
+def s3gw_factory(static_dir: str | None = None) -> FastAPI:
     api_tags_meta = [
         {
             "name": "bucket",
@@ -97,15 +85,15 @@ def s3gw_factory(
         description="<s3gw description>",
         version="1.0.0",
         openapi_tags=api_tags_meta,
+        lifespan=lifespan,
     )
 
-    @s3gw_app.on_event("startup")
-    async def on_startup():  # type: ignore
-        await startup(s3gw_app, s3gw_api)
-
-    @s3gw_app.on_event("shutdown")
-    async def on_shutdown():  # type: ignore
-        await shutdown(s3gw_app, s3gw_api)
+    try:
+        s3gw_api.state.config = Config()
+    except Exception as exception:
+        logger.error(str(exception))
+        logger.error("unable to init config -- exit!")
+        sys.exit(1)
 
     s3gw_api.include_router(admin.router)
     s3gw_api.include_router(auth.router)
@@ -113,7 +101,7 @@ def s3gw_factory(
     s3gw_api.include_router(objects.router)
     s3gw_api.include_router(config.router)
 
-    s3gw_app.mount(s3gw_api.state.config.api_location(), s3gw_api, name="api")
+    s3gw_app.mount(s3gw_api.state.config.api_location, s3gw_api, name="api")
 
     if static_dir is not None:
         # Disable caching of `index.html` on purpose so that the browser
@@ -121,7 +109,7 @@ def s3gw_factory(
         # app are not taken into account when the browser is loading the
         # file from the cache.
         s3gw_app.mount(
-            s3gw_api.state.config.ui_location(),
+            s3gw_api.state.config.ui_location,
             NoCacheStaticFiles(
                 no_cache_files=["/"], directory=static_dir, html=True
             ),
@@ -135,7 +123,7 @@ def app_factory():
     static_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "frontend/dist/s3gw-ui/"
     )
-    return s3gw_factory(s3gw_startup, s3gw_shutdown, static_dir)
+    return s3gw_factory(static_dir)
 
 
 def main():


### PR DESCRIPTION
Support installing and serving the UI from a sub path

This is necessary to make it possible to link from the Longhorn UI to the s3gw UI.
The way this is intended to be utilized is to make the Longhorn UI available under http://*/longhorn and the s3gw UI of each instance of the s3gw in that Longhorn cluster available under http://*/${INSTANCE_ID}, e.g. http://*/s3store
In this case, the hostname is not relevant and can be configured by the user

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
