### PR TITLE
Fix validation error for `DeletedObject`

### DIFF
--- a/src/backend/api/types.py
+++ b/src/backend/api/types.py
@@ -116,7 +116,7 @@ class Object(BaseModel):
 class DeletedObject(BaseModel):
     Key: str
     VersionId: Optional[str] = None
-    DeleteMarker: bool
+    DeleteMarker: Optional[bool] = None
     DeleteMarkerVersionId: Optional[str] = None
 
 


### PR DESCRIPTION
Make the `DeleteMarker` property optional because it seems it does not always exist (anymore) in the API response.

Fixes: https://github.com/aquarist-labs/s3gw/issues/795
