### PR TITLE
Add support for configuring S3 addressing style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow the deletion of specific object versions (gh#aquarist-labs/s3gw#764).
+- Add `S3GW_S3_ADDRESSING_STYLE` environment variable to configure the S3 addressing style (gh#aquarist-labs/s3gw#770). 
 
 ## [0.22.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,120 +9,120 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent user from logging out when deleting a locked object version (gh#aquarist-labs/s3gw#789).
-- Fix an error when deleting an object in an unversioned bucket (gh#aquarist-labs/s3gw#795).
+- Prevent user from logging out when deleting a locked object version (aquarist-labs/s3gw#789).
+- Fix an error when deleting an object in an unversioned bucket (aquarist-labs/s3gw#795).
 
 ### Added
 
-- Allow the deletion of specific object versions (gh#aquarist-labs/s3gw#764).
-- Add `S3GW_S3_ADDRESSING_STYLE` environment variable to configure the S3 addressing style (gh#aquarist-labs/s3gw#770). 
+- Allow the deletion of specific object versions (aquarist-labs/s3gw#764).
+- Add `S3GW_S3_ADDRESSING_STYLE` environment variable to configure the S3 addressing style (aquarist-labs/s3gw#770). 
 
 ## [0.22.0]
 
 ### Changed
 
-- Show at least one datatable column (gh#aquarist-labs/s3gw#560).
+- Show at least one datatable column (aquarist-labs/s3gw#560).
 
 ### Fixed
 
-- Fix several theming issues (gh#aquarist-labs/s3gw#728).
+- Fix several theming issues (aquarist-labs/s3gw#728).
 - Disable `Restore` and `Download` action buttons in object version
-  page correctly (gh#aquarist-labs/s3gw#747).
+  page correctly (aquarist-labs/s3gw#747).
 
 ## [0.21.0]
 
 ### Changed
 
-- Make use of the UI REST API to prevent CORS issues (gh#aquarist-labs/s3gw#680).
+- Make use of the UI REST API to prevent CORS issues (aquarist-labs/s3gw#680).
 
 ### Fixed
 
-- Prevent switching bucket retention mode from `Compliance` to `Governance` (gh#aquarist-labs/s3gw#553).
+- Prevent switching bucket retention mode from `Compliance` to `Governance` (aquarist-labs/s3gw#553).
 
 ## [0.20.0]
 
 ### Changed
 
-- Disable versioning checkbox after bucket creation (gh#aquarist-labs/s3gw#672).
-- Do not restore latest object version (gh#aquarist-labs/s3gw#678).
+- Disable versioning checkbox after bucket creation (aquarist-labs/s3gw#672).
+- Do not restore latest object version (aquarist-labs/s3gw#678).
 
 ## [0.19.0]
 
 ### Added
 
-- Add 'Administrator' checkbox to user create/edit dialog (gh#aquarist-labs/s3gw#636).
+- Add 'Administrator' checkbox to user create/edit dialog (aquarist-labs/s3gw#636).
 
 ### Fixed
 
-- Table column header breaks on zoom-in (gh#aquarist-labs/s3gw#618).
-- Remove scroll option from table column header (gh#aquarist-labs/s3gw#633).
-- Specifying manual user keys is not possible (gh#aquarist-labs/s3gw#652).
+- Table column header breaks on zoom-in (aquarist-labs/s3gw#618).
+- Remove scroll option from table column header (aquarist-labs/s3gw#633).
+- Specifying manual user keys is not possible (aquarist-labs/s3gw#652).
 
 ## [0.18.0]
 
 ### Added
 
-- Add a hint to the prefix field in the lifecycle rule dialog (gh#aquarist-labs/s3gw#600).
+- Add a hint to the prefix field in the lifecycle rule dialog (aquarist-labs/s3gw#600).
 
 ### Changed
 
-- Enhance branding support (gh#aquarist-labs/s3gw#552) (gh#aquarist-labs/s3gw#572).
+- Enhance branding support (aquarist-labs/s3gw#552) (aquarist-labs/s3gw#572).
 
 ### Fixed
 
-- Deleting a versioned object is not properly implemented (gh#aquarist-labs/s3gw#550).
-- Do not delete object by version (gh#aquarist-labs/s3gw#576).
-- Prevent the restoring of the deleted object version (gh#aquarist-labs/s3gw#583).
-- Creating an enabled lifecycle rule is not working (gh#aquarist-labs/s3gw#587).
-- Disable download button for deleted objects (gh#aquarist-labs/s3gw#595).
-- Do not close datatable column menu on inside clicks (gh#aquarist-labs/s3gw#599).
+- Deleting a versioned object is not properly implemented (aquarist-labs/s3gw#550).
+- Do not delete object by version (aquarist-labs/s3gw#576).
+- Prevent the restoring of the deleted object version (aquarist-labs/s3gw#583).
+- Creating an enabled lifecycle rule is not working (aquarist-labs/s3gw#587).
+- Disable download button for deleted objects (aquarist-labs/s3gw#595).
+- Do not close datatable column menu on inside clicks (aquarist-labs/s3gw#599).
 
 ## [0.17.0]
 
 ### Added
 
-- Add object version management (gh#aquarist-labs/s3gw#255).
-- Add branding support (gh#aquarist-labs/s3gw#552).
+- Add object version management (aquarist-labs/s3gw#255).
+- Add branding support (aquarist-labs/s3gw#552).
 
 ### Fixed
 
-- Do not display objects that have also a delete marker (gh#aquarist-labs/s3gw#548).
-- Search button only performs a search on a page level (gh#aquarist-labs/s3gw#556).
-- The datatable pagination does not show the correct number of displayed items (gh#aquarist-labs/s3gw#559).
+- Do not display objects that have also a delete marker (aquarist-labs/s3gw#548).
+- Search button only performs a search on a page level (aquarist-labs/s3gw#556).
+- The datatable pagination does not show the correct number of displayed items (aquarist-labs/s3gw#559).
 
 ## [0.16.0]
 
 ### Removed
 
-- Disable bucket and user quotas in the UI (gh#aquarist-labs/s3gw#503).
+- Disable bucket and user quotas in the UI (aquarist-labs/s3gw#503).
 
 ## [0.15.0]
 
 ### Added
 
-- Add tags support for objects (gh#aquarist-labs/s3gw#304).
+- Add tags support for objects (aquarist-labs/s3gw#304).
 
 ### Removed
 
-- Remove .github/workflows/build.yaml (gh#aquarist-labs/s3gw#444)
+- Remove .github/workflows/build.yaml (aquarist-labs/s3gw#444)
 
 ## [0.14.0]
 
 ### Added
 
 - Add button to copy the current path of the object browser to the clipboard.
-- Support legal holds on objects (gh#aquarist-labs/s3gw#365).
-- Add support to manage lifecycle rules per bucket (gh#aquarist-labs/s3gw#349).
+- Support legal holds on objects (aquarist-labs/s3gw#365).
+- Add support to manage lifecycle rules per bucket (aquarist-labs/s3gw#349).
 
 ### Changed
 
-- Display object data more intuitively (gh#aquarist-labs/s3gw#350).
+- Display object data more intuitively (aquarist-labs/s3gw#350).
 
 ## [0.13.0]
 
 ### Added
 
-- Add support for bucket object locking (gh#aquarist-labs/s3gw#313).
+- Add support for bucket object locking (aquarist-labs/s3gw#313).
 
 ### Changed
 
@@ -132,53 +132,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support folders in object explorer (gh#aquarist-labs/s3gw#241).
+- Support folders in object explorer (aquarist-labs/s3gw#241).
 
 ## [0.11.0]
 
 ### Added
 
-- Add tags support for buckets (gh#aquarist-labs/s3gw#285).
-- Add notification sidebar (gh#aquarist-labs/s3gw#172).
+- Add tags support for buckets (aquarist-labs/s3gw#285).
+- Add notification sidebar (aquarist-labs/s3gw#172).
 - Add option to remove buckets objects before deleting a bucket
   in the administrator view.
 
 ### Known Issues
 
-- It is not possible to remove all tags (gh#aquarist-labs/s3gw#314).
-- It is not possible to change the bucket owner (gh#aquarist-labs/s3gw#86).
+- It is not possible to remove all tags (aquarist-labs/s3gw#314).
+- It is not possible to change the bucket owner (aquarist-labs/s3gw#86).
 
 ## [0.10.0] - 2022-12-22
 
 ### Fixed
 
-- Editing buckets in `user` mode is not possible (gh#aquarist-labs/s3gw#262).
-- A page reload does not re-enable the 'administration' switch (gh#aquarist-labs/s3gw#284).
+- Editing buckets in `user` mode is not possible (aquarist-labs/s3gw#262).
+- A page reload does not re-enable the 'administration' switch (aquarist-labs/s3gw#284).
 - Editing buckets in `user` mode is not possible because form is in
-  `Create` mode only (gh#aquarist-labs/s3gw#290).
+  `Create` mode only (aquarist-labs/s3gw#290).
 
 ### Added
 
-- Add search field to data tables (gh#aquarist-labs/s3gw#157).
-- Display progress while bootstrapping the app (gh#aquarist-labs/s3gw#247).
-- Make datatable pagination settings persistent (gh#aquarist-labs/s3gw#242).
-- Add ability to show/hide columns (gh#aquarist-labs/s3gw#65).
-- Display more object information (gh#aquarist-labs/s3gw#286).
+- Add search field to data tables (aquarist-labs/s3gw#157).
+- Display progress while bootstrapping the app (aquarist-labs/s3gw#247).
+- Make datatable pagination settings persistent (aquarist-labs/s3gw#242).
+- Add ability to show/hide columns (aquarist-labs/s3gw#65).
+- Display more object information (aquarist-labs/s3gw#286).
 
 ## [0.9.0] - 2022-12-01
 
 ### Fixed
 
-- Creating a bucket with spaces crashed the app (gh#aquarist-labs/s3gw#225).
-- Fix URL in the dashboard buckets widget (gh#aquarist-labs/s3gw#240).
+- Creating a bucket with spaces crashed the app (aquarist-labs/s3gw#225).
+- Fix URL in the dashboard buckets widget (aquarist-labs/s3gw#240).
 
 ### Added
 
-- Add multi-selection support to data tables (gh#aquarist-labs/s3gw#135).
+- Add multi-selection support to data tables (aquarist-labs/s3gw#135).
 
 ### Changed
 
-- Combine the regular and administrator UI (gh#aquarist-labs/s3gw#175).
+- Combine the regular and administrator UI (aquarist-labs/s3gw#175).
 
 ## [0.8.0] - 2022-11-10
 
@@ -190,8 +190,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Display an error message on the login page if the RGW endpoint is not
   configured correctly.
-- Add basic object management features (gh#aquarist-labs/s3gw#146).
-- Add feature to upload objects into buckets via browser (gh#aquarist-labs/s3gw#167).
+- Add basic object management features (aquarist-labs/s3gw#146).
+- Add feature to upload objects into buckets via browser (aquarist-labs/s3gw#167).
 
 ## [0.7.0] - 2022-10-20
 
@@ -202,7 +202,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Login page does not show error messages (gh#aquarist-labs/s3gw#136).
+- Login page does not show error messages (aquarist-labs/s3gw#136).
 
 ### Changed
 

--- a/src/backend/api/__init__.py
+++ b/src/backend/api/__init__.py
@@ -16,7 +16,7 @@
 
 import contextlib
 import re
-from typing import Annotated, Any, AsyncGenerator, Dict, Tuple, cast
+from typing import Annotated, Any, AsyncGenerator, Dict, Literal, Tuple, cast
 
 import boto3.utils
 import pydash
@@ -27,7 +27,7 @@ from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.logger import logger
 from types_aiobotocore_s3.client import S3Client
 
-from backend.config import Config, S3AddressingStyle
+from backend.config import Config
 
 
 class S3GWClient:
@@ -71,8 +71,8 @@ class S3GWClient:
         return self._secret_key
 
     @property
-    def addressing_style(self) -> S3AddressingStyle:
-        return self._config.s3_addressing_style
+    def addressing_style(self) -> Literal["auto", "virtual", "path"]:
+        return self._config.s3_addressing_style.value
 
     @contextlib.asynccontextmanager
     async def conn(self, attempts: int = 1) -> AsyncGenerator[S3Client, None]:

--- a/src/backend/api/__init__.py
+++ b/src/backend/api/__init__.py
@@ -27,7 +27,7 @@ from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.logger import logger
 from types_aiobotocore_s3.client import S3Client
 
-from backend.config import Config
+from backend.config import Config, S3AddressingStyle
 
 
 class S3GWClient:
@@ -43,7 +43,9 @@ class S3GWClient:
     _access_key: str
     _secret_key: str
 
-    def __init__(self, endpoint: str, access_key: str, secret_key: str) -> None:
+    def __init__(
+        self, config: Config, access_key: str, secret_key: str
+    ) -> None:
         """
         Creates a new `S3GWClient` instance.
 
@@ -52,13 +54,13 @@ class S3GWClient:
         * `access_key`: the user's `access key`.
         * `secret_key`: the user's `secret access key`.
         """
-        self._endpoint = endpoint
+        self._config = config
         self._access_key = access_key
         self._secret_key = secret_key
 
     @property
     def endpoint(self) -> str:
-        return self._endpoint
+        return self._config.s3gw_addr
 
     @property
     def access_key(self) -> str:
@@ -67,6 +69,10 @@ class S3GWClient:
     @property
     def secret_key(self) -> str:
         return self._secret_key
+
+    @property
+    def addressing_style(self) -> S3AddressingStyle:
+        return self._config.s3_addressing_style
 
     @contextlib.asynccontextmanager
     async def conn(self, attempts: int = 1) -> AsyncGenerator[S3Client, None]:
@@ -101,7 +107,10 @@ class S3GWClient:
                 retries={
                     "max_attempts": attempts,
                     "mode": "standard",
-                }
+                },
+                s3={
+                    "addressing_style": self.addressing_style,
+                },
             ),
         ) as client:
             try:
@@ -109,10 +118,10 @@ class S3GWClient:
             except ClientError as e:
                 (status_code, detail) = decode_client_error(e)
                 raise HTTPException(status_code=status_code, detail=detail)
-            except EndpointConnectionError:
+            except EndpointConnectionError as e:
                 raise HTTPException(
                     status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail="Endpoint not found",
+                    detail=str(e),
                 )
             except SSLError:
                 raise HTTPException(
@@ -154,13 +163,13 @@ def decode_client_error(e: ClientError) -> Tuple[int, str]:
     )
 
 
-def s3gw_endpoint(request: Request) -> str:
+def s3gw_config(request: Request) -> Config:
     config: Config = request.app.state.config
-    return config.s3gw_addr
+    return config
 
 
 async def s3gw_client(
-    endpoint: Annotated[str, Depends(s3gw_endpoint)],
+    config: Annotated[Config, Depends(s3gw_config)],
     s3gw_credentials: Annotated[str, Header()],
 ) -> S3GWClient:
     """
@@ -179,7 +188,7 @@ async def s3gw_client(
     assert len(m.groups()) == 2
     access, secret = m.group(1), m.group(2)
     assert len(access) > 0 and len(secret) > 0
-    return S3GWClient(endpoint, access, secret)
+    return S3GWClient(config, access, secret)
 
 
 def s3gw_client_responses() -> Dict[int | str, Dict[str, Any]]:

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -14,11 +14,21 @@
 
 import os
 import re
-from typing import Literal
+from enum import Enum, EnumMeta
+from typing import Any
 
 from fastapi.logger import logger
 
-S3AddressingStyle = Literal["auto", "virtual", "path"]
+
+class S3AddressingStyleEnumMeta(EnumMeta):
+    def __contains__(self, item: Any):
+        return item in self._value2member_map_
+
+
+class S3AddressingStyle(Enum, metaclass=S3AddressingStyleEnumMeta):
+    AUTO = "auto"
+    VIRTUAL = "virtual"
+    PATH = "path"
 
 
 def get_s3gw_address() -> str:
@@ -61,13 +71,13 @@ def get_s3_addressing_style() -> S3AddressingStyle:
     """
     Obtain the S3 addressing style. Defaults to `auto`.
     """
-    addressing_style: str | None = os.environ.get("S3GW_S3_ADDRESSING_STYLE")
-    if addressing_style is not None:
-        addressing_style = addressing_style.lower()
-    if addressing_style not in ["auto", "virtual", "path"]:
-        addressing_style = "auto"
+    addressing_style: str = os.environ.get(
+        "S3GW_S3_ADDRESSING_STYLE", "auto"
+    ).lower()
+    if addressing_style not in S3AddressingStyle:
+        addressing_style = S3AddressingStyle.AUTO.value
     logger.info(f"Using '{addressing_style}' S3 addressing style")
-    return addressing_style  # noqa # pyright: ignore [reportGeneralTypeIssues]
+    return S3AddressingStyle(addressing_style)
 
 
 class Config:

--- a/src/backend/tests/unit/api/test_api.py
+++ b/src/backend/tests/unit/api/test_api.py
@@ -17,6 +17,7 @@ from botocore.exceptions import ClientError
 from fastapi import HTTPException, status
 
 from backend.api import S3GWClient, decode_client_error, s3gw_client
+from backend.config import S3AddressingStyle
 from backend.tests.unit.helpers import ConfigMock
 
 
@@ -69,9 +70,9 @@ async def test_s3gw_client_bad_endpoint() -> None:
 @pytest.mark.anyio
 async def test_s3gw_client_addressing_style() -> None:
     s3gw_client = S3GWClient(
-        ConfigMock("https://abc.xyz", "path"), "foo", "bar"
+        ConfigMock("https://abc.xyz", S3AddressingStyle.PATH), "foo", "bar"
     )
-    assert "path" == s3gw_client.addressing_style
+    assert S3AddressingStyle.PATH.value == s3gw_client.addressing_style
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/conftest.py
+++ b/src/backend/tests/unit/conftest.py
@@ -20,6 +20,7 @@ import pytest
 from fastapi import Response
 
 from backend.api import S3GWClient
+from backend.tests.unit.helpers import ConfigMock
 from backend.tests.unit.moto_server import MotoService
 
 if os.environ.get("S3GW_TEST_DEBUG") is not None:
@@ -64,7 +65,7 @@ async def s3_client(s3_server: str) -> AsyncGenerator[S3GWClient, None]:
     assert srv.startswith("http")
     assert access is not None and len(access) > 0
     assert secret is not None and len(secret) > 0
-    yield S3GWClient(srv, access, secret)
+    yield S3GWClient(ConfigMock(srv), access, secret)
 
 
 @pytest.fixture

--- a/src/backend/tests/unit/helpers.py
+++ b/src/backend/tests/unit/helpers.py
@@ -20,6 +20,7 @@ from pytest_mock import MockerFixture
 from pytest_mock.plugin import MockType
 
 from backend.api import S3GWClient
+from backend.config import Config, S3AddressingStyle
 
 
 def async_return(result: Any):
@@ -51,3 +52,11 @@ class S3ApiMock:
                     patch_args["attribute"]
                 ] = self._mocker.patch.object(s3, **patch_args)
             yield s3
+
+
+class ConfigMock(Config):
+    def __init__(
+        self, s3gw_addr: str, s3_addressing_style: S3AddressingStyle = "auto"
+    ) -> None:  # noqa
+        self._s3gw_addr = s3gw_addr
+        self._s3_addressing_style = s3_addressing_style

--- a/src/backend/tests/unit/helpers.py
+++ b/src/backend/tests/unit/helpers.py
@@ -56,7 +56,9 @@ class S3ApiMock:
 
 class ConfigMock(Config):
     def __init__(
-        self, s3gw_addr: str, s3_addressing_style: S3AddressingStyle = "auto"
+        self,
+        s3gw_addr: str,
+        s3_addressing_style: S3AddressingStyle = S3AddressingStyle.AUTO,
     ) -> None:  # noqa
         self._s3gw_addr = s3gw_addr
         self._s3_addressing_style = s3_addressing_style

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -21,6 +21,7 @@ from starlette.datastructures import State
 from backend.api import s3gw_config
 from backend.config import (
     Config,
+    S3AddressingStyle,
     get_s3_addressing_style,
     get_s3gw_address,
     get_ui_path,
@@ -140,14 +141,14 @@ def test_api_path_with_trailing_slash() -> None:
 
 def test_get_s3_addressing_style_1() -> None:
     os.environ["S3GW_S3_ADDRESSING_STYLE"] = "foo"
-    assert "auto" == get_s3_addressing_style()
+    assert S3AddressingStyle.AUTO == get_s3_addressing_style()
 
 
 def test_get_s3_addressing_style_2() -> None:
     os.environ["S3GW_S3_ADDRESSING_STYLE"] = "VIRTUAL"
-    assert "virtual" == get_s3_addressing_style()
+    assert S3AddressingStyle.VIRTUAL == get_s3_addressing_style()
 
 
 def test_get_s3_addressing_style_3() -> None:
     os.environ.pop("S3GW_S3_ADDRESSING_STYLE", None)
-    assert "auto" == get_s3_addressing_style()
+    assert S3AddressingStyle.AUTO == get_s3_addressing_style()

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -18,8 +18,13 @@ import pytest
 from fastapi import FastAPI, Request
 from starlette.datastructures import State
 
-from backend.api import s3gw_endpoint
-from backend.config import Config, get_s3gw_address, get_ui_path
+from backend.api import s3gw_config
+from backend.config import (
+    Config,
+    get_s3_addressing_style,
+    get_s3gw_address,
+    get_ui_path,
+)
 
 
 def test_s3gw_malformed_address() -> None:
@@ -78,8 +83,8 @@ def test_s3gw_endpoint() -> None:
     app = FastAPI()
     app.state = State({"config": Config()})
     req = Request({"type": "http", "app": app})
-    res: str = s3gw_endpoint(req)
-    assert res == addr
+    config: Config = s3gw_config(req)
+    assert config.s3gw_addr == addr
 
 
 def test_malformed_ui_path() -> None:
@@ -131,3 +136,18 @@ def test_api_path_with_trailing_slash() -> None:
         assert cfg.api_path == "/s3store/api"
     except Exception as e:
         pytest.fail(str(e))
+
+
+def test_get_s3_addressing_style_1() -> None:
+    os.environ["S3GW_S3_ADDRESSING_STYLE"] = "foo"
+    assert "auto" == get_s3_addressing_style()
+
+
+def test_get_s3_addressing_style_2() -> None:
+    os.environ["S3GW_S3_ADDRESSING_STYLE"] = "VIRTUAL"
+    assert "virtual" == get_s3_addressing_style()
+
+
+def test_get_s3_addressing_style_3() -> None:
+    os.environ.pop("S3GW_S3_ADDRESSING_STYLE", None)
+    assert "auto" == get_s3_addressing_style()


### PR DESCRIPTION
The environment variable `S3GW_S3_ADDRESSING_STYLE` supports the following options:

- auto
- path
- virtual

It defaults to `auto`.

Additional enhancements:
- Use a more detailed error message in case of an endpoint connection error.
- Improve several unit tests.

Fixes: https://github.com/aquarist-labs/s3gw/issues/770
