### PR TITLE
Deleting a not empty bucket displays a misleading error

### DIFF
--- a/src/backend/api/__init__.py
+++ b/src/backend/api/__init__.py
@@ -157,7 +157,9 @@ def decode_client_error(e: ClientError) -> Tuple[int, str]:
             status_code = int(code)
             detail = pydash.get(e.response, "Error.Message")
         else:
-            detail = pydash.get(e.response, "Error.Message", code)
+            detail = pydash.default_to(
+                pydash.get(e.response, "Error.Message", code), code
+            )
     return status_code, pydash.human_case(
         pydash.default_to(detail, "UnknownError")
     )

--- a/src/backend/tests/unit/api/test_api.py
+++ b/src/backend/tests/unit/api/test_api.py
@@ -141,3 +141,22 @@ def test_decode_client_error_4() -> None:
     (status_code, detail) = decode_client_error(error)
     assert status_code == status.HTTP_403_FORBIDDEN
     assert detail == "Invalid access key"
+
+
+def test_decode_client_error_5() -> None:
+    error = ClientError(
+        error_response={
+            "Error": {
+                "BucketName": "e2ebucket",
+                "Code": "BucketNotEmpty",
+                "Message": None,  # pyright: ignore [reportGeneralTypeIssues]
+            },
+            "ResponseMetadata": {  # pyright: ignore [reportGeneralTypeIssues]
+                "HTTPStatusCode": 409
+            },
+        },
+        operation_name="TestOperation",
+    )
+    (status_code, detail) = decode_client_error(error)
+    assert status_code == status.HTTP_409_CONFLICT
+    assert detail == "Bucket not empty"


### PR DESCRIPTION
The response error contains `None` for the `Message` field which is not allowed in the type def so this case was simply not taken into account because it was out of spec.

Fixes: https://github.com/aquarist-labs/s3gw/issues/812
