### PR TITLE
Deleting a not empty bucket displays a misleading error

### DIFF
--- a/src/frontend/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
+++ b/src/frontend/src/app/pages/user/object/object-datatable-page/object-datatable-page.component.ts
@@ -611,12 +611,14 @@ export class ObjectDatatablePageComponent implements OnInit {
         total: fileList.length
       })
     );
+    let loaded = 0;
     this.subscriptions.add(
       this.s3BucketService
         .uploadObjects(this.bid, fileList, this.s3BucketService.buildPrefix(this.prefixParts))
         .pipe(finalize(() => this.blockUiService.stop()))
         .subscribe({
           next: (progress: S3UploadProgress) => {
+            loaded = progress.loaded;
             this.blockUiService.update(
               translate(
                 TEXT(
@@ -631,8 +633,13 @@ export class ObjectDatatablePageComponent implements OnInit {
             );
           },
           complete: () => {
+            const message: string =
+              loaded === fileList.length
+                ? TEXT('{{ total }} object(s) have been successfully uploaded.')
+                : TEXT('{{ loaded }} of {{ total }} object(s) have been successfully uploaded.');
             this.notificationService.showSuccess(
-              translate(TEXT('{{ total }} object(s) have been successfully uploaded.'), {
+              translate(message, {
+                loaded,
                 total: fileList.length
               })
             );


### PR DESCRIPTION
Modify the success message if the number of loaded files is lower than the total number of uploaded files. This is the case when one or several file uploads failed.

Fixes: https://github.com/aquarist-labs/s3gw/issues/818

(cherry picked from commit 9e1b90577103f5b373e85f0362e1db880a334445)
