### PR TITLE
fix: ui path validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 .PHONY: check-ui-backend-env
+.DEFAULT_GOAL:=image-build-ui
 
 ########################################################################
 # Testing cluster
@@ -103,5 +104,3 @@ check-ui-backend-env:
 ifndef S3GW_SERVICE_URL
 	$(error S3GW_SERVICE_URL must be set.)
 endif
-
-

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -120,7 +120,8 @@ def get_ui_path() -> str:
     def post_process(key: str, value: str | None) -> str:
         if value is None or value == "/":
             return "/"
-        match = re.fullmatch(r"[\w/-]+[\w/]+", value)
+        # TODO: The path should be validated here
+        match = re.fullmatch(r".*", value)
         if match is None:
             logger.error(
                 f"The value of the environment variable {key} is malformed: {value}"  # noqa: E501

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -120,7 +120,7 @@ def get_ui_path() -> str:
     def post_process(key: str, value: str | None) -> str:
         if value is None or value == "/":
             return "/"
-        match = re.fullmatch(r"/?[\w./-]+(?:[\w]+)/?", value)
+        match = re.fullmatch(r"[\w/-]+[\w/]+", value)
         if match is None:
             logger.error(
                 f"The value of the environment variable {key} is malformed: {value}"  # noqa: E501

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -131,6 +131,11 @@ def test_good_ui_path_3() -> None:
     assert "/foo-bar/baz/" == get_ui_path()
 
 
+def test_good_ui_path_4() -> None:
+    os.environ["S3GW_UI_PATH"] = "/foo-bar/foo-bar/"
+    assert "/foo-bar/foo-bar/" == get_ui_path()
+
+
 def test_no_ui_path() -> None:
     os.environ.pop("S3GW_UI_PATH")
     try:

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -95,6 +95,7 @@ def test_s3gw_endpoint() -> None:
     assert config.s3gw_addr == addr
 
 
+@pytest.mark.skip(reason="UI paths are currently not validated")
 def test_malformed_ui_path() -> None:
     bad_paths = [
         "",
@@ -110,6 +111,7 @@ def test_malformed_ui_path() -> None:
         )
 
 
+@pytest.mark.skip(reason="UI paths are currently not validated")
 def test_malformed_ui_path_2() -> None:
     os.environ["S3GW_UI_PATH"] = "/foo-bar/baz?aaa"
     with pytest.raises(EnvironMalformedError):


### PR DESCRIPTION
Fix validation of the UI application path by removing it.

This removes the buggy regex that tries in vain to validate that the user configured a correct path. This is a must-have for v0.23 as it otherwise breaks Longhorn integration.

Fixes: https://github.com/aquarist-labs/s3gw/issues/834

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR
